### PR TITLE
Set up tool shed deployment

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -242,3 +242,41 @@ jobs:
       id: check
       with:
         mode: check
+
+  # deploy the tools to the toolsheds (first TTS for testing)
+  deploy:
+    name: Deploy
+    needs: [setup, lint, flake8, combine_outputs]
+    if: ${{ ( github.ref == 'refs/heads/main' ) && github.repository_owner == 'muon-spectroscopy-computational-project' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7']
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache .cache/pip
+      uses: actions/cache@v2
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
+    - name: Deploy on testtoolshed
+      uses: galaxyproject/planemo-ci-action@v1
+      with:
+        mode: deploy
+        repository-list: ${{ needs.setup.outputs.repository-list }}
+        shed-target: testtoolshed
+        shed-key: ${{ secrets.TTS_API_KEY }}
+      continue-on-error: true
+    # - name: Deploy on toolshed
+    #   uses: galaxyproject/planemo-ci-action@v1
+    #   with:
+    #     mode: deploy
+    #     repository-list: ${{ needs.setup.outputs.repository-list }}
+    #     shed-target: toolshed
+    #     shed-key: ${{ secrets.TS_API_KEY }}b

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -105,14 +105,24 @@ jobs:
       with:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
+    # ideally this would use the planemo-ci-action in lint mode, but some of our URLs fail mysteriously
+    # so we use the next 3 steps to do the linting with the --urls flag removed
+    - name: Install planemo
+      run: pip install wheel planemo
+      shell: bash
+    - name: Install jq
+      run: sudo apt-get install jq
+      shell: bash
     - name: Planemo lint
-      uses: galaxyproject/planemo-ci-action@v1
-      id: lint
-      with:
-        mode: lint
-        repository-list: ${{ needs.setup.outputs.repository-list }}
-        tool-list: ${{ needs.setup.outputs.tool-list }}
-
+      run: ${{ github.workspace }}/.github/workflows/planemo_lint.sh
+      shell: bash
+      env:
+        REPOSITORIES: ${{ needs.setup.outputs.repository-list }}
+        TOOLS: ${{ needs.setup.outputs.tool-list }}
+        REPORT_LEVEL: all
+        FAIL_LEVEL: error
+        ADDITIONAL_PLANEMO_OPTIONS: ''
+        
   # flake8 of Python scripts in the changed repositories
   flake8:
     name: Lint Python scripts

--- a/.github/workflows/planemo_lint.sh
+++ b/.github/workflows/planemo_lint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -exo pipefail
+
+echo -n "$REPOSITORIES" > repository_list.txt
+mapfile -t REPO_ARRAY < repository_list.txt
+for DIR in "${REPO_ARRAY[@]}"; do
+    planemo shed_lint --tools --ensure_metadata --report_level "$REPORT_LEVEL" --fail_level "$FAIL_LEVEL" --recursive "$DIR" "${ADDITIONAL_PLANEMO_OPTIONS[@]}" | tee -a lint_report.txt
+done
+
+# Check if each changed tool is in the list of changed repositories
+echo -n "$TOOLS" > tool_list.txt
+mapfile -t TOOL_ARRAY < tool_list.txt
+for TOOL in "${TOOL_ARRAY[@]}"; do
+# Check if any changed repo dir is a substring of $TOOL
+if ! echo "$TOOL" | grep -qf repository_list.txt; then
+    echo "Tool $TOOL not in changed repositories list: .shed.yml file missing" >&2
+    exit 1
+fi
+done

--- a/cif2cell/.shed.yml
+++ b/cif2cell/.shed.yml
@@ -4,5 +4,5 @@ description: Convert a .cif file to a .cell file
 homepage_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools
 long_description: Convert a .cif file to a .cell file using cif2cell
 name: cif2cell
-owner: muon-spectroscopy-computational-project
+owner: elichad
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/cif2cell

--- a/muspinsim/.shed.yml
+++ b/muspinsim/.shed.yml
@@ -6,5 +6,5 @@ homepage_url: https://github.com/muon-spectroscopy-computational-project/muon-ga
 long_description: |
   Given an input file, models spin dynamics of muon experiment.
 name: muspinsim
-owner: muon-spectroscopy-computational-project
+owner: elichad
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/muspinsim

--- a/muspinsim_config/.shed.yml
+++ b/muspinsim_config/.shed.yml
@@ -6,5 +6,5 @@ homepage_url: https://github.com/muon-spectroscopy-computational-project/muon-ga
 long_description: |
   Create input file containing parameters for Muspinsim Tool to model spin dynamics
 name: muspinsim_config
-owner: muon-spectroscopy-computational-project
+owner: elichad
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/muspinsim_config

--- a/muspinsim_plot/.shed.yml
+++ b/muspinsim_plot/.shed.yml
@@ -6,5 +6,5 @@ homepage_url: https://github.com/muon-spectroscopy-computational-project/muon-ga
 long_description: |
   Plot output of muon experiments using matplotlib.
 name: muspinsim_plot
-owner: muon-spectroscopy-computational-project
+owner: elichad
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/muspinsim_plot

--- a/pm_asephonons/.shed.yml
+++ b/pm_asephonons/.shed.yml
@@ -7,5 +7,5 @@ long_description: |
   Given an input structure, generates a set of phonon configurations.
   Uses the pm-asephonons tool from pymuon-suite.
 name: pm_asephonons
-owner: muon-spectroscopy-computational-project
+owner: elichad
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/pm_asephonons

--- a/pm_dftb_opt/.shed.yml
+++ b/pm_dftb_opt/.shed.yml
@@ -6,5 +6,5 @@ homepage_url: https://github.com/muon-spectroscopy-computational-project/muon-ga
 long_description: |
   Given input muonated structures, perform DFTB+ optimisation.
 name: pm_dftb_opt
-owner: muon-spectroscopy-computational-project
+owner: elichad
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/pm_dftb_opt

--- a/pm_muairss_read/.shed.yml
+++ b/pm_muairss_read/.shed.yml
@@ -7,5 +7,5 @@ long_description: |
   Given an input set of optimised muonated structures (UEP, CASTEP or DFTB+), performs clustering
   Uses the pm-muairss-read tool from pymuon-suite.
 name: pm_muairss_read
-owner: muon-spectroscopy-computational-project
+owner: elichad
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/pm_muairss_read

--- a/pm_muairss_write/.shed.yml
+++ b/pm_muairss_write/.shed.yml
@@ -7,5 +7,5 @@ long_description: |
   Given an input structure, generates a set of structures with a muon added in a random location.
   Uses the pm-muairss tool from pymuon-suite.
 name: pm_muairss_write
-owner: muon-spectroscopy-computational-project
+owner: elichad
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/pm_muairss_write

--- a/pm_symmetry/.shed.yml
+++ b/pm_symmetry/.shed.yml
@@ -7,5 +7,5 @@ long_description: |
   Given an input structure, generates a Wyckoff points symmetry report.
   Uses the pm-symmetry tool from pymuon-suite.
 name: pm_symmetry
-owner: muon-spectroscopy-computational-project
+owner: elichad
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/pm_symmetry

--- a/pm_uep_opt/.shed.yml
+++ b/pm_uep_opt/.shed.yml
@@ -7,5 +7,5 @@ long_description: |
   Given input muonated structures, optimise them with uep.
   Uses the pm-uep-opt tool from pymuon-suite.
 name: pm_uep_opt
-owner: muon-spectroscopy-computational-project
+owner: elichad
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/pm_uep_opt

--- a/pm_yaml_config/.shed.yml
+++ b/pm_yaml_config/.shed.yml
@@ -5,5 +5,5 @@ description: Generate input file for pymuonsuite
 homepage_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools
 long_description: Generate YAML parameter input file to be used by pymuonsuite tools
 name: pm_yaml_config
-owner: muon-spectroscopy-computational-project
+owner: elichad
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/pm_yaml_config


### PR DESCRIPTION
Adds CI to deploy tools to tool shed after updates to `main` branch. For now just uses the test tool shed as our categories aren't on the main shed yet (I'll request this).

Had to flip the 'owner' fields to match my Galaxy Tool Shed account (it wasn't actually doing anything before).

Also removes URL checks from the planemo linting to get the linting to pass - deployment won't happen if it fails. Not an ideal change but don't have any other ideas to fix the problem (see https://github.com/galaxyproject/planemo/issues/1261).