### PR TITLE
revert owners to a generic MSCP name

### DIFF
--- a/cif2cell/.shed.yml
+++ b/cif2cell/.shed.yml
@@ -4,5 +4,5 @@ description: Convert a .cif file to a .cell file
 homepage_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools
 long_description: Convert a .cif file to a .cell file using cif2cell
 name: cif2cell
-owner: elichad
+owner: muon-spectroscopy-computational-project
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/cif2cell

--- a/muspinsim/.shed.yml
+++ b/muspinsim/.shed.yml
@@ -6,5 +6,5 @@ homepage_url: https://github.com/muon-spectroscopy-computational-project/muon-ga
 long_description: |
   Given an input file, models spin dynamics of muon experiment.
 name: muspinsim
-owner: elichad
+owner: muon-spectroscopy-computational-project
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/muspinsim

--- a/muspinsim_config/.shed.yml
+++ b/muspinsim_config/.shed.yml
@@ -6,5 +6,5 @@ homepage_url: https://github.com/muon-spectroscopy-computational-project/muon-ga
 long_description: |
   Create input file containing parameters for Muspinsim Tool to model spin dynamics
 name: muspinsim_config
-owner: elichad
+owner: muon-spectroscopy-computational-project
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/muspinsim_config

--- a/muspinsim_plot/.shed.yml
+++ b/muspinsim_plot/.shed.yml
@@ -6,5 +6,5 @@ homepage_url: https://github.com/muon-spectroscopy-computational-project/muon-ga
 long_description: |
   Plot output of muon experiments using matplotlib.
 name: muspinsim_plot
-owner: elichad
+owner: muon-spectroscopy-computational-project
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/muspinsim_plot

--- a/pm_asephonons/.shed.yml
+++ b/pm_asephonons/.shed.yml
@@ -7,5 +7,5 @@ long_description: |
   Given an input structure, generates a set of phonon configurations.
   Uses the pm-asephonons tool from pymuon-suite.
 name: pm_asephonons
-owner: elichad
+owner: muon-spectroscopy-computational-project
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/pm_asephonons

--- a/pm_dftb_opt/.shed.yml
+++ b/pm_dftb_opt/.shed.yml
@@ -6,5 +6,5 @@ homepage_url: https://github.com/muon-spectroscopy-computational-project/muon-ga
 long_description: |
   Given input muonated structures, perform DFTB+ optimisation.
 name: pm_dftb_opt
-owner: elichad
+owner: muon-spectroscopy-computational-project
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/pm_dftb_opt

--- a/pm_muairss_read/.shed.yml
+++ b/pm_muairss_read/.shed.yml
@@ -7,5 +7,5 @@ long_description: |
   Given an input set of optimised muonated structures (UEP, CASTEP or DFTB+), performs clustering
   Uses the pm-muairss-read tool from pymuon-suite.
 name: pm_muairss_read
-owner: elichad
+owner: muon-spectroscopy-computational-project
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/pm_muairss_read

--- a/pm_muairss_write/.shed.yml
+++ b/pm_muairss_write/.shed.yml
@@ -7,5 +7,5 @@ long_description: |
   Given an input structure, generates a set of structures with a muon added in a random location.
   Uses the pm-muairss tool from pymuon-suite.
 name: pm_muairss_write
-owner: elichad
+owner: muon-spectroscopy-computational-project
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/pm_muairss_write

--- a/pm_symmetry/.shed.yml
+++ b/pm_symmetry/.shed.yml
@@ -7,5 +7,5 @@ long_description: |
   Given an input structure, generates a Wyckoff points symmetry report.
   Uses the pm-symmetry tool from pymuon-suite.
 name: pm_symmetry
-owner: elichad
+owner: muon-spectroscopy-computational-project
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/pm_symmetry

--- a/pm_uep_opt/.shed.yml
+++ b/pm_uep_opt/.shed.yml
@@ -7,5 +7,5 @@ long_description: |
   Given input muonated structures, optimise them with uep.
   Uses the pm-uep-opt tool from pymuon-suite.
 name: pm_uep_opt
-owner: elichad
+owner: muon-spectroscopy-computational-project
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/pm_uep_opt

--- a/pm_yaml_config/.shed.yml
+++ b/pm_yaml_config/.shed.yml
@@ -5,5 +5,5 @@ description: Generate input file for pymuonsuite
 homepage_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools
 long_description: Generate YAML parameter input file to be used by pymuonsuite tools
 name: pm_yaml_config
-owner: elichad
+owner: muon-spectroscopy-computational-project
 remote_repository_url: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/main/pm_yaml_config


### PR DESCRIPTION
on advice from @bgruening.

I moved my original test shed account to another email and set up a new one with the public name 'muon-spectroscopy-computational-project' to match the github org.