### PR TITLE
Replace bibtex citations with DOIs

### DIFF
--- a/cif2cell/cif2cell.xml
+++ b/cif2cell/cif2cell.xml
@@ -42,21 +42,6 @@
         Uses electronic structure program 'castep'
     ]]></help>
     <citations>
-        <citation type="bibtex">
-            @article{cif2cell,
-                author = {Torbj\"orn Bj\"orkman},
-                title = {CIF2Cell: Generating geometries for electronic structure programs},
-                journal = {Computer Physics Communications},
-                volume = {182},
-                number = {5},
-                pages = {1183 - 1186},
-                year = {2011},
-                issn = {0010-4655},
-                doi={10.1016/j.cpc.2011.01.013},
-                URL={
-                    http://www.sciencedirect.com/science/article/pii/S0010465511000336
-                }
-            }
-        </citation>
+        <citation type="doi">10.1016/j.cpc.2011.01.013</citation>
     </citations>
 </tool>

--- a/muspinsim_config/muspinsim_config.xml
+++ b/muspinsim_config/muspinsim_config.xml
@@ -465,18 +465,7 @@
         - Scipy default tolerance is :code:`1e-5`
     ]]></help>
     <citations>
-        <citation type="bibtex">
-            @article{nelder_mead_1965,
-                title={A Simplex Method for Function Minimization},
-                volume={7},
-                doi={10.1093/comjnl/7.4.308},
-                number={4},
-                journal={The Computer Journal},
-                author={Nelder, J. A. and Mead, R.},
-                year={1965},
-                pages={308-313}
-            }
-        </citation>
+        <citation type="doi">10.1093/comjnl/7.4.308</citation>
         <citation type="bibtex">
             @book{nocedal_wright_2006,
                 place={New York (NY)},

--- a/pm_asephonons/pm_asephonons.xml
+++ b/pm_asephonons/pm_asephonons.xml
@@ -115,24 +115,7 @@
         <citation type="bibtex">
             @PYMUONSUITE_CITATION@
         </citation>
-        <citation type="bibtex">
-            @article{doi:10.1063/1.5085197,
-                author = {Sturniolo,Simone  and Liborio,Leandro  and Jackson,Samuel },
-                title = {Comparison between density functional theory and density functional tight binding approaches for finding the muon stopping site in organic molecular crystals},
-                journal = {The Journal of Chemical Physics},
-                volume = {150},
-                number = {15},
-                pages = {154301},
-                year = {2019},
-                doi = {10.1063/1.5085197},
-                URL = {
-                        https://doi.org/10.1063/1.5085197
-                },
-                eprint = {
-                        https://doi.org/10.1063/1.5085197
-                }
-            }
-        </citation>
+        <citation type="doi">10.1063/1.5085197</citation>
         <citation type="bibtex">
             @article{larsen2017atomic,
                 title={The atomic simulation environment—a Python library for working with atoms},

--- a/pm_dftb_opt/pm_dftb_opt.xml
+++ b/pm_dftb_opt/pm_dftb_opt.xml
@@ -118,25 +118,6 @@
         <citation type="bibtex">
             @PYMUONSUITE_CITATION@
         </citation>
-        <citation type="bibtex">
-        @article{doi:10.1063/1.5143190,
-         author = {Hourahine,B.  and Aradi,B.  and Blum,V.  and Bonafé,F.  and Buccheri,A.  and Camacho,C.  and Cevallos,C.  and Deshaye,M. Y.  and Dumitrică,T.  and Dominguez,A.  and Ehlert,S.  and Elstner,M.  and van der Heide,T.  and Hermann,J.  and Irle,S.  and Kranz,J. J.  and Köhler,C.  and Kowalczyk,T.  and Kubař,T.  and Lee,I. S.  and Lutsker,V.  and Maurer,R. J.  and Min,S. K.  and Mitchell,I.  and Negre,C.  and Niehaus,T. A.  and Niklasson,A. M. N.  and Page,A. J.  and Pecchia,A.  and Penazzi,G.  and Persson,M. P.  and Řezáč,J.  and Sánchez,C. G.  and Sternberg,M.  and Stöhr,M.  and Stuckenberg,F.  and Tkatchenko,A.  and Yu,V. W.-z.  and Frauenheim,T. },
-         title = {DFTB+, a software package for efficient approximate density functional theory based atomistic simulations},
-         journal = {The Journal of Chemical Physics},
-         volume = {152},
-         number = {12},
-         pages = {124101},
-         year = {2020},
-         doi = {10.1063/1.5143190},
-
-         URL = {
-                 https://doi.org/10.1063/1.5143190
-
-         },
-         eprint = {
-                 https://doi.org/10.1063/1.5143190
-         }
-         }
-        </citation>
+        <citation type="doi">10.1063/1.5143190</citation>
     </citations>
 </tool>

--- a/pm_muairss_read/pm_muairss_read.xml
+++ b/pm_muairss_read/pm_muairss_read.xml
@@ -90,60 +90,9 @@
         <citation type="bibtex">
             @TOOL_CITATION@
         </citation>
-        <citation type="bibtex">
-            @article{airss,
-                author = {Liborio, L. and Sturniolo, S. and Jochym, D.},
-                title = {Computational prediction of muon stopping sites using ab initio random structure searching (AIRSS)},
-                journal = {The Journal of Chemical Physics},
-                volume = {148},
-                pages = {134114},
-                year = {2018},
-                doi={10.1063/1.5024450},
-                URL={
-                    https://doi.org/10.1063/1.5024450
-                },
-                eprint={
-                    https://doi.org/10.1063/1.5024450
-                }
-            }
-        </citation>
-        <citation type="bibtex">
-            @article{doi:10.1063/1.5085197,
-                author = {Sturniolo,Simone  and Liborio,Leandro  and Jackson,Samuel },
-                title = {Comparison between density functional theory and density functional tight binding approaches for finding the muon stopping site in organic molecular crystals},
-                journal = {The Journal of Chemical Physics},
-                volume = {150},
-                number = {15},
-                pages = {154301},
-                year = {2019},
-                doi = {10.1063/1.5085197},
-                URL = {
-                        https://doi.org/10.1063/1.5085197
-                },
-                eprint = {
-                        https://doi.org/10.1063/1.5085197
-                }
-            }
-        </citation>
-        <citation type="bibtex">
-            @article{doi:10.1063/5.0012381,
-                author = {Sturniolo,Simone  and Liborio,Leandro },
-                title = {Computational prediction of muon stopping sites: A novel take on the unperturbed electrostatic potential method},
-                journal = {The Journal of Chemical Physics},
-                volume = {153},
-                number = {4},
-                pages = {044111},
-                year = {2020},
-                doi = {10.1063/5.0012381},
-                URL = {
-                        https://doi.org/10.1063/5.0012381
-                },
-                eprint = {
-                        https://doi.org/10.1063/5.0012381
-                },
-                abstract = { Finding the stopping site of the muon in a muon-spin relaxation experiment is one of the main problems of muon spectroscopy, and computational techniques that make use of quantum chemistry simulations can be of great help when looking for this stopping site. The most thorough approach would require the use of simulations, such as Density Functional Theory (DFT), to test and optimise multiple possible sites, accounting for the effect that the added muon has on its surroundings. However, this can be computationally expensive and sometimes unnecessary. Hence, in this work, we present a software implementation of the Unperturbed Electrostatic Potential (UEP) Method: an approach used for finding the muon stopping site in crystalline materials. The UEP method requires only one DFT calculation, necessary to compute the electronic density. This, in turn, is used to calculate the minima of the crystalline material’s electrostatic potential and the estimates of the muon stopping site, relying on the approximation that the muon’s presence does not significantly affect its surroundings. One of the main UEP’s assumptions is that the muon stopping site will be one of the crystalline material’s electrostatic potential minima. In this regard, we also propose some symmetry-based considerations about the properties of this crystalline material’s electrostatic potential, in particular, which sites are more likely to be its minima and why the unperturbed approximation may be sufficiently robust for them. We introduce the Python software package pymuon-suite and the various utilities it provides to facilitate these calculations, and finally, we demonstrate the effectiveness of the method with some chosen example systems. }
-            }
-        </citation>
+        <citation type="doi">10.1063/1.5024450</citation>
+        <citation type="doi">10.1063/1.5085197</citation>
+        <citation type="doi">10.1063/5.0012381</citation>
         <citation type="bibtex">
             @article {castep,
                 author = {Clark, S. J. and Segall, M. D. and Pickard, C. J. and Hasnip, P. J. and Probert, M. I. J. and Refson, K. and Payne, M. C.},

--- a/pm_muairss_write/pm_muairss_write.xml
+++ b/pm_muairss_write/pm_muairss_write.xml
@@ -185,60 +185,9 @@
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite/}
             }
         </citation>
-        <citation type="bibtex">
-            @article{airss,
-                author = {Liborio, L. and Sturniolo, S. and Jochym, D.},
-                title = {Computational prediction of muon stopping sites using ab initio random structure searching (AIRSS)},
-                journal = {The Journal of Chemical Physics},
-                volume = {148},
-                pages = {134114},
-                year = {2018},
-                doi={10.1063/1.5024450},
-                URL={
-                    https://doi.org/10.1063/1.5024450
-                },
-                eprint={
-                    https://doi.org/10.1063/1.5024450
-                }
-            }
-        </citation>
-        <citation type="bibtex">
-            @article{doi:10.1063/1.5085197,
-                author = {Sturniolo,Simone  and Liborio,Leandro  and Jackson,Samuel },
-                title = {Comparison between density functional theory and density functional tight binding approaches for finding the muon stopping site in organic molecular crystals},
-                journal = {The Journal of Chemical Physics},
-                volume = {150},
-                number = {15},
-                pages = {154301},
-                year = {2019},
-                doi = {10.1063/1.5085197},
-                URL = {
-                        https://doi.org/10.1063/1.5085197
-                },
-                eprint = {
-                        https://doi.org/10.1063/1.5085197
-                }
-            }
-        </citation>
-        <citation type="bibtex">
-            @article{doi:10.1063/5.0012381,
-                author = {Sturniolo,Simone  and Liborio,Leandro },
-                title = {Computational prediction of muon stopping sites: A novel take on the unperturbed electrostatic potential method},
-                journal = {The Journal of Chemical Physics},
-                volume = {153},
-                number = {4},
-                pages = {044111},
-                year = {2020},
-                doi = {10.1063/5.0012381},
-                URL = {
-                        https://doi.org/10.1063/5.0012381
-                },
-                eprint = {
-                        https://doi.org/10.1063/5.0012381
-                },
-                abstract = { Finding the stopping site of the muon in a muon-spin relaxation experiment is one of the main problems of muon spectroscopy, and computational techniques that make use of quantum chemistry simulations can be of great help when looking for this stopping site. The most thorough approach would require the use of simulations, such as Density Functional Theory (DFT), to test and optimize multiple possible sites, accounting for the effect that the added muon has on its surroundings. However, this can be computationally expensive and sometimes unnecessary. Hence, in this work, we present a software implementation of the Unperturbed Electrostatic Potential (UEP) Method: an approach used for finding the muon stopping site in crystalline materials. The UEP method requires only one DFT calculation, necessary to compute the electronic density. This, in turn, is used to calculate the minima of the crystalline material’s electrostatic potential and the estimates of the muon stopping site, relying on the approximation that the muon’s presence does not significantly affect its surroundings. One of the main UEP’s assumptions is that the muon stopping site will be one of the crystalline material’s electrostatic potential minima. In this regard, we also propose some symmetry-based considerations about the properties of this crystalline material’s electrostatic potential, in particular, which sites are more likely to be its minima and why the unperturbed approximation may be sufficiently robust for them. We introduce the Python software package pymuon-suite and the various utilities it provides to facilitate these calculations, and finally, we demonstrate the effectiveness of the method with some chosen example systems. }
-            }
-        </citation>
+        <citation type="doi">10.1063/1.5024450</citation>
+        <citation type="doi">10.1063/1.5085197</citation>
+        <citation type="doi">10.1063/5.0012381</citation>
         <citation type="bibtex">
             @TOOL_CITATION@
         </citation>

--- a/pm_symmetry/pm_symmetry.xml
+++ b/pm_symmetry/pm_symmetry.xml
@@ -68,24 +68,6 @@
         <citation type="bibtex">
             @TOOL_CITATION@
         </citation>
-        <citation type="bibtex">
-            @article{doi:10.1063/5.0012381,
-                author = {Sturniolo,Simone  and Liborio,Leandro },
-                title = {Computational prediction of muon stopping sites: A novel take on the unperturbed electrostatic potential method},
-                journal = {The Journal of Chemical Physics},
-                volume = {153},
-                number = {4},
-                pages = {044111},
-                year = {2020},
-                doi = {10.1063/5.0012381},
-                URL = {
-                        https://doi.org/10.1063/5.0012381
-                },
-                eprint = {
-                        https://doi.org/10.1063/5.0012381
-                },
-                abstract = { Finding the stopping site of the muon in a muon-spin relaxation experiment is one of the main problems of muon spectroscopy, and computational techniques that make use of quantum chemistry simulations can be of great help when looking for this stopping site. The most thorough approach would require the use of simulations, such as Density Functional Theory (DFT), to test and optimise multiple possible sites, accounting for the effect that the added muon has on its surroundings. However, this can be computationally expensive and sometimes unnecessary. Hence, in this work, we present a software implementation of the Unperturbed Electrostatic Potential (UEP) Method: an approach used for finding the muon stopping site in crystalline materials. The UEP method requires only one DFT calculation, necessary to compute the electronic density. This, in turn, is used to calculate the minima of the crystalline material’s electrostatic potential and the estimates of the muon stopping site, relying on the approximation that the muon’s presence does not significantly affect its surroundings. One of the main UEP’s assumptions is that the muon stopping site will be one of the crystalline material’s electrostatic potential minima. In this regard, we also propose some symmetry-based considerations about the properties of this crystalline material’s electrostatic potential, in particular, which sites are more likely to be its minima and why the unperturbed approximation may be sufficiently robust for them. We introduce the Python software package pymuon-suite and the various utilities it provides to facilitate these calculations, and finally, we demonstrate the effectiveness of the method with some chosen example systems. }
-            }
-        </citation>
+        <citation type="doi">10.1063/5.0012381</citation>
     </citations>
 </tool>

--- a/pm_uep_opt/pm_uep_opt.xml
+++ b/pm_uep_opt/pm_uep_opt.xml
@@ -107,60 +107,9 @@
         <citation type="bibtex">
             @TOOL_CITATION@
         </citation>
-        <citation type="bibtex">
-            @article{airss,
-                author = {Liborio, L. and Sturniolo, S. and Jochym, D.},
-                title = {Computational prediction of muon stopping sites using ab initio random structure searching (AIRSS)},
-                journal = {The Journal of Chemical Physics},
-                volume = {148},
-                pages = {134114},
-                year = {2018},
-                doi={10.1063/1.5024450},
-                URL={
-                    https://doi.org/10.1063/1.5024450
-                },
-                eprint={
-                    https://doi.org/10.1063/1.5024450
-                }
-            }
-        </citation>
-        <citation type="bibtex">
-            @article{doi:10.1063/1.5085197,
-                author = {Sturniolo,Simone  and Liborio,Leandro  and Jackson,Samuel },
-                title = {Comparison between density functional theory and density functional tight binding approaches for finding the muon stopping site in organic molecular crystals},
-                journal = {The Journal of Chemical Physics},
-                volume = {150},
-                number = {15},
-                pages = {154301},
-                year = {2019},
-                doi = {10.1063/1.5085197},
-                URL = {
-                        https://doi.org/10.1063/1.5085197
-                },
-                eprint = {
-                        https://doi.org/10.1063/1.5085197
-                }
-            }
-        </citation>
-        <citation type="bibtex">
-            @article{doi:10.1063/5.0012381,
-                author = {Sturniolo,Simone  and Liborio,Leandro },
-                title = {Computational prediction of muon stopping sites: A novel take on the unperturbed electrostatic potential method},
-                journal = {The Journal of Chemical Physics},
-                volume = {153},
-                number = {4},
-                pages = {044111},
-                year = {2020},
-                doi = {10.1063/5.0012381},
-                URL = {
-                        https://doi.org/10.1063/5.0012381
-                },
-                eprint = {
-                        https://doi.org/10.1063/5.0012381
-                },
-                abstract = { Finding the stopping site of the muon in a muon-spin relaxation experiment is one of the main problems of muon spectroscopy, and computational techniques that make use of quantum chemistry simulations can be of great help when looking for this stopping site. The most thorough approach would require the use of simulations, such as Density Functional Theory (DFT), to test and optimise multiple possible sites, accounting for the effect that the added muon has on its surroundings. However, this can be computationally expensive and sometimes unnecessary. Hence, in this work, we present a software implementation of the Unperturbed Electrostatic Potential (UEP) Method: an approach used for finding the muon stopping site in crystalline materials. The UEP method requires only one DFT calculation, necessary to compute the electronic density. This, in turn, is used to calculate the minima of the crystalline material’s electrostatic potential and the estimates of the muon stopping site, relying on the approximation that the muon’s presence does not significantly affect its surroundings. One of the main UEP’s assumptions is that the muon stopping site will be one of the crystalline material’s electrostatic potential minima. In this regard, we also propose some symmetry-based considerations about the properties of this crystalline material’s electrostatic potential, in particular, which sites are more likely to be its minima and why the unperturbed approximation may be sufficiently robust for them. We introduce the Python software package pymuon-suite and the various utilities it provides to facilitate these calculations, and finally, we demonstrate the effectiveness of the method with some chosen example systems. }
-            }
-        </citation>
+        <citation type="doi">10.1063/1.5024450</citation>
+        <citation type="doi">10.1063/1.5085197</citation>
+        <citation type="doi">10.1063/5.0012381</citation>
         <citation type="bibtex">
             @article {castep,
                 author = {Clark, S. J. and Segall, M. D. and Pickard, C. J. and Hasnip, P. J. and Probert, M. I. J. and Refson, K. and Payne, M. C.},


### PR DESCRIPTION
In every case where we had a DOI, I've replaced the `bibtex` citation with a `doi` type citation.

I've checked against the dev server, as far as I can tell the only place with any inconsistency is in [pm_dftb_opt.xml](https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/compare/patrick/93-bibtex-to-doi?expand=1#diff-26f80979afa2a3fc5cb7c5488e673e1dc02a3f73600bbd1cfe1882ee4dc95011) - "DFTB+" now displays as "DFTB\mathplus". If this is a significant issue, we could leave this as a `bibtex` citation.

Also worth noting that if testing using a Galaxy instance without the fix here galaxyproject/galaxy#14225 all the DOI links will be broken. As far as I know we're still running 22.1: muon-spectroscopy-computational-project/muon-galaxy#22

Closes #93 