### PR TITLE
Add license attribute to all tools

### DIFF
--- a/cif2cell/cif2cell.xml
+++ b/cif2cell/cif2cell.xml
@@ -1,4 +1,4 @@
-<tool id="cif2cell" name="cif2cell" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="GPL-3.0-only">
+<tool id="cif2cell" name="cif2cell" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="MIT">
     <description>convert .cif file to .cell</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
@@ -40,6 +40,8 @@
 
         Given an input .cif structure file, convert to equivalent .cell structure file.
         Uses electronic structure program 'castep'
+
+        Note that while this tool uses the MIT license, cif2cell itself is distributed under GPLv3.
     ]]></help>
     <citations>
         <citation type="bibtex">

--- a/cif2cell/cif2cell.xml
+++ b/cif2cell/cif2cell.xml
@@ -1,4 +1,4 @@
-<tool id="cif2cell" name="cif2cell" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01">
+<tool id="cif2cell" name="cif2cell" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="GPL-3.0-only">
     <description>convert .cif file to .cell</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->

--- a/cif2cell/cif2cell.xml
+++ b/cif2cell/cif2cell.xml
@@ -41,7 +41,7 @@
         Given an input .cif structure file, convert to equivalent .cell structure file.
         Uses electronic structure program 'castep'
 
-        Note that while this tool uses the MIT license, cif2cell itself is distributed under GPLv3.
+        cif2cell is distributed under the GPLv3 license. This tool wrapper is distributed under the MIT license.
     ]]></help>
     <citations>
         <citation type="bibtex">

--- a/muspinsim/muspinsim.xml
+++ b/muspinsim/muspinsim.xml
@@ -1,4 +1,4 @@
-<tool id="muspinsim" name="MuSpinSim Simulate" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01">
+<tool id="muspinsim" name="MuSpinSim Simulate" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="MIT">
     <description>perform spin dynamics calculations for muon science experiments</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->

--- a/muspinsim_config/muspinsim_config.xml
+++ b/muspinsim_config/muspinsim_config.xml
@@ -1,4 +1,4 @@
-<tool id="muspinsim_config" name="MuSpinSim Configure" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01">
+<tool id="muspinsim_config" name="MuSpinSim Configure" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="MIT">
     <description>define simulation parameters</description>
        <macros>
         <!-- version of underlying tool (PEP 440) -->

--- a/muspinsim_plot/muspinsim_plot.xml
+++ b/muspinsim_plot/muspinsim_plot.xml
@@ -1,4 +1,4 @@
-<tool id="muspinsim_plot" name="MuSpinSim Plot" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01">
+<tool id="muspinsim_plot" name="MuSpinSim Plot" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="MIT">
     <macros>
         <!-- version of underlying tool (PEP 440) -->
         <token name="@TOOL_VERSION@">3.5.1</token>

--- a/pm_asephonons/pm_asephonons.xml
+++ b/pm_asephonons/pm_asephonons.xml
@@ -1,4 +1,4 @@
-<tool id="pm_asephonons" name="PyMuonSuite Phonons" version="0.1.1" python_template_version="3.5" profile="22.01">
+<tool id="pm_asephonons" name="PyMuonSuite Phonons" version="0.1.1" python_template_version="3.5" profile="22.01" license="GPL-3.0-only">
     <description>calculate phonons using ASE and DFTB+</description>
     <macros>
         <!-- citation should be updated with every underlying tool version -->
@@ -6,7 +6,7 @@
         <token name="@PYMUONSUITE_CITATION@">
             @software{pymuon-suite,
                 author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and {Muon Spectroscopy Computational Project}},
-                license = {GPL-3.0},
+                license = {GPL-3.0-only},
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
                 version = {v0.2.1},

--- a/pm_asephonons/pm_asephonons.xml
+++ b/pm_asephonons/pm_asephonons.xml
@@ -1,4 +1,4 @@
-<tool id="pm_asephonons" name="PyMuonSuite Phonons" version="0.1.1" python_template_version="3.5" profile="22.01" license="GPL-3.0-only">
+<tool id="pm_asephonons" name="PyMuonSuite Phonons" version="0.1.1" python_template_version="3.5" profile="22.01" license="MIT">
     <description>calculate phonons using ASE and DFTB+</description>
     <macros>
         <!-- citation should be updated with every underlying tool version -->
@@ -110,6 +110,7 @@
 
         Given an input structure, this tool generates a phonon report for that structure using the parameters provided.
 
+        Note that while this tool uses the MIT license, PyMuonSuite itself is distributed under GPLv3.
     ]]></help>
     <citations>
         <citation type="bibtex">

--- a/pm_asephonons/pm_asephonons.xml
+++ b/pm_asephonons/pm_asephonons.xml
@@ -110,7 +110,7 @@
 
         Given an input structure, this tool generates a phonon report for that structure using the parameters provided.
 
-        Note that while this tool uses the MIT license, PyMuonSuite itself is distributed under GPLv3.
+        PyMuonSuite is distributed under the GPLv3 license. This tool wrapper is distributed under the MIT license.
     ]]></help>
     <citations>
         <citation type="bibtex">

--- a/pm_dftb_opt/pm_dftb_opt.xml
+++ b/pm_dftb_opt/pm_dftb_opt.xml
@@ -1,4 +1,4 @@
-<tool id="pm_dftb_opt" name="PyMuonSuite AIRSS DFTB+ Optimise" version="0.1.1" python_template_version="3.5" profile="22.01" license="GPL-3.0-only">
+<tool id="pm_dftb_opt" name="PyMuonSuite AIRSS DFTB+ Optimise" version="0.1.1" python_template_version="3.5" profile="22.01" license="MIT">
     <description>run DFTB+ optimisation</description>
     <macros>
         <!-- citation should be updated with every underlying tool version -->
@@ -70,6 +70,8 @@
     <help><![CDATA[
         usage: dftb+
         Given some input muonated structures (structures containing a muon), applies DFTB+ optimization to refine them.
+        
+        Note that while this tool uses the MIT license, PyMuonSuite itself is distributed under GPLv3.
 
         **LICENSE**
 

--- a/pm_dftb_opt/pm_dftb_opt.xml
+++ b/pm_dftb_opt/pm_dftb_opt.xml
@@ -1,4 +1,4 @@
-<tool id="pm_dftb_opt" name="PyMuonSuite AIRSS DFTB+ Optimise" version="0.1.1" python_template_version="3.5" profile="22.01">
+<tool id="pm_dftb_opt" name="PyMuonSuite AIRSS DFTB+ Optimise" version="0.1.1" python_template_version="3.5" profile="22.01" license="GPL-3.0-only">
     <description>run DFTB+ optimisation</description>
     <macros>
         <!-- citation should be updated with every underlying tool version -->
@@ -6,7 +6,7 @@
         <token name="@PYMUONSUITE_CITATION@">
             @software{pymuon-suite,
                 author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and {Muon Spectroscopy Computational Project}},
-                license = {GPL-3.0},
+                license = {GPL-3.0-only},
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
                 version = {v0.2.1},

--- a/pm_dftb_opt/pm_dftb_opt.xml
+++ b/pm_dftb_opt/pm_dftb_opt.xml
@@ -71,7 +71,7 @@
         usage: dftb+
         Given some input muonated structures (structures containing a muon), applies DFTB+ optimization to refine them.
         
-        Note that while this tool uses the MIT license, PyMuonSuite itself is distributed under GPLv3.
+        PyMuonSuite is distributed under the GPLv3 license. This tool wrapper is distributed under the MIT license.
 
         **LICENSE**
 

--- a/pm_muairss_read/pm_muairss_read.xml
+++ b/pm_muairss_read/pm_muairss_read.xml
@@ -89,7 +89,7 @@
 
         Command-line usage: pm-muairss [-h] -t r structures parameter_file
 
-        Note that while this tool uses the MIT license, PyMuonSuite itself is distributed under GPLv3.
+        PyMuonSuite is distributed under the GPLv3 license. This tool wrapper is distributed under the MIT license.
     ]]></help>
     <citations>
         <citation type="bibtex">

--- a/pm_muairss_read/pm_muairss_read.xml
+++ b/pm_muairss_read/pm_muairss_read.xml
@@ -1,4 +1,4 @@
-<tool id="pm_muairss_read" name="PyMuonSuite AIRSS Cluster" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="GPL-3.0-only">
+<tool id="pm_muairss_read" name="PyMuonSuite AIRSS Cluster" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="MIT">
     <description>run clustering for optimised structures</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
@@ -88,6 +88,8 @@
         'Generate muon structures' tool or pm-muairss.
 
         Command-line usage: pm-muairss [-h] -t r structures parameter_file
+
+        Note that while this tool uses the MIT license, PyMuonSuite itself is distributed under GPLv3.
     ]]></help>
     <citations>
         <citation type="bibtex">

--- a/pm_muairss_read/pm_muairss_read.xml
+++ b/pm_muairss_read/pm_muairss_read.xml
@@ -1,4 +1,4 @@
-<tool id="pm_muairss_read" name="PyMuonSuite AIRSS Cluster" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01">
+<tool id="pm_muairss_read" name="PyMuonSuite AIRSS Cluster" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="GPL-3.0-only">
     <description>run clustering for optimised structures</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
@@ -10,7 +10,7 @@
         <token name="@TOOL_CITATION@">
             @software{pymuon-suite,
                 author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and {Muon Spectroscopy Computational Project}},
-                license = {GPL-3.0},
+                license = {GPL-3.0-only},
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
                 version = {v0.2.1},

--- a/pm_muairss_write/pm_muairss_write.xml
+++ b/pm_muairss_write/pm_muairss_write.xml
@@ -178,7 +178,7 @@
         .. _YAML config generator: /tool_runner?tool_id=pm_yaml_config
         .. _Generate UEP outputs: /tool_runner?tool_id=pm_uep_opt_write
 
-        Note that while this tool uses the MIT license, PyMuonSuite itself is distributed under GPLv3.
+        PyMuonSuite is distributed under the GPLv3 license. This tool wrapper is distributed under the MIT license.
     ]]></help>
     <citations>
         <citation type="bibtex">

--- a/pm_muairss_write/pm_muairss_write.xml
+++ b/pm_muairss_write/pm_muairss_write.xml
@@ -1,4 +1,4 @@
-<tool id="pm_muairss_write" name="PyMuonSuite AIRSS Generate" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="GPL-3.0-only">
+<tool id="pm_muairss_write" name="PyMuonSuite AIRSS Generate" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="MIT">
     <description>generate muonated structures</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
@@ -177,6 +177,8 @@
         .. _pm-muairss documentation: https://github.com/muon-spectroscopy-computational-project/pymuon-suite/blob/master/docs/muairss-gen-docs.md
         .. _YAML config generator: /tool_runner?tool_id=pm_yaml_config
         .. _Generate UEP outputs: /tool_runner?tool_id=pm_uep_opt_write
+
+        Note that while this tool uses the MIT license, PyMuonSuite itself is distributed under GPLv3.
     ]]></help>
     <citations>
         <citation type="bibtex">

--- a/pm_muairss_write/pm_muairss_write.xml
+++ b/pm_muairss_write/pm_muairss_write.xml
@@ -1,4 +1,4 @@
-<tool id="pm_muairss_write" name="PyMuonSuite AIRSS Generate" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01">
+<tool id="pm_muairss_write" name="PyMuonSuite AIRSS Generate" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="GPL-3.0-only">
     <description>generate muonated structures</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
@@ -10,7 +10,7 @@
         <token name="@TOOL_CITATION@">
             @software{pymuon-suite,
                 author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and {Muon Spectroscopy Computational Project}},
-                license = {GPL-3.0},
+                license = {GPL-3.0-only},
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
                 version = {v0.2.1},

--- a/pm_symmetry/pm_symmetry.xml
+++ b/pm_symmetry/pm_symmetry.xml
@@ -1,4 +1,4 @@
-<tool id="pm_symmetry" name="PyMuonSuite Symmetry" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="GPL-3.0-only">
+<tool id="pm_symmetry" name="PyMuonSuite Symmetry" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="MIT">
     <description>generate Wyckoff points symmetry report</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
@@ -63,6 +63,8 @@
         usage: pm-symmetry structure
 
         Given an input structure, generates a Wyckoff points symmetry report for that structure.
+        
+        Note that while this tool uses the MIT license, PyMuonSuite itself is distributed under GPLv3.
     ]]></help>
     <citations>
         <citation type="bibtex">

--- a/pm_symmetry/pm_symmetry.xml
+++ b/pm_symmetry/pm_symmetry.xml
@@ -64,7 +64,7 @@
 
         Given an input structure, generates a Wyckoff points symmetry report for that structure.
         
-        Note that while this tool uses the MIT license, PyMuonSuite itself is distributed under GPLv3.
+        PyMuonSuite is distributed under the GPLv3 license. This tool wrapper is distributed under the MIT license.
     ]]></help>
     <citations>
         <citation type="bibtex">

--- a/pm_symmetry/pm_symmetry.xml
+++ b/pm_symmetry/pm_symmetry.xml
@@ -1,4 +1,4 @@
-<tool id="pm_symmetry" name="PyMuonSuite Symmetry" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01">
+<tool id="pm_symmetry" name="PyMuonSuite Symmetry" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="GPL-3.0-only">
     <description>generate Wyckoff points symmetry report</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
@@ -10,7 +10,7 @@
         <token name="@TOOL_CITATION@">
             @software{pymuon-suite,
                 author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and {Muon Spectroscopy Computational Project}},
-                license = {GPL-3.0},
+                license = {GPL-3.0-only},
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
                 version = {v0.2.1},

--- a/pm_uep_opt/pm_uep_opt.xml
+++ b/pm_uep_opt/pm_uep_opt.xml
@@ -1,4 +1,4 @@
-<tool id="pm_uep_opt" name="PyMuonSuite AIRSS UEP Optimise" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01">
+<tool id="pm_uep_opt" name="PyMuonSuite AIRSS UEP Optimise" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="GPL-3.0-only">
     <description>run UEP optimisation</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
@@ -10,7 +10,7 @@
         <token name="@TOOL_CITATION@">
             @software{pymuon-suite,
                 author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and {Muon Spectroscopy Computational Project}},
-                license = {GPL-3.0},
+                license = {GPL-3.0-only},
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
                 version = {v0.2.1},

--- a/pm_uep_opt/pm_uep_opt.xml
+++ b/pm_uep_opt/pm_uep_opt.xml
@@ -1,4 +1,4 @@
-<tool id="pm_uep_opt" name="PyMuonSuite AIRSS UEP Optimise" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="GPL-3.0-only">
+<tool id="pm_uep_opt" name="PyMuonSuite AIRSS UEP Optimise" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="MIT">
     <description>run UEP optimisation</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
@@ -106,6 +106,8 @@
         Command-line usage: pm-uep-opt [-h] [-t {r,w}] structures parameter_file
 
         .. _Generate muonated structures: /tool_runner?tool_id=pm_muairss_write
+
+        Note that while this tool uses the MIT license, PyMuonSuite itself is distributed under GPLv3.
     ]]></help>
     <citations>
         <citation type="bibtex">

--- a/pm_uep_opt/pm_uep_opt.xml
+++ b/pm_uep_opt/pm_uep_opt.xml
@@ -107,7 +107,7 @@
 
         .. _Generate muonated structures: /tool_runner?tool_id=pm_muairss_write
 
-        Note that while this tool uses the MIT license, PyMuonSuite itself is distributed under GPLv3.
+        PyMuonSuite is distributed under the GPLv3 license. This tool wrapper is distributed under the MIT license.
     ]]></help>
     <citations>
         <citation type="bibtex">

--- a/pm_yaml_config/pm_yaml_config.xml
+++ b/pm_yaml_config/pm_yaml_config.xml
@@ -215,7 +215,7 @@
     <help><![CDATA[
         Creates a YAML configuration file from input parameters.
 
-        Note that while this tool uses the MIT license, PyMuonSuite itself is distributed under GPLv3.
+        PyMuonSuite is distributed under the GPLv3 license. This tool wrapper is distributed under the MIT license.
 
       **DFTB+ parameter sets:**
 

--- a/pm_yaml_config/pm_yaml_config.xml
+++ b/pm_yaml_config/pm_yaml_config.xml
@@ -1,4 +1,4 @@
-<tool id="pm_yaml_config" name="PyMuonSuite AIRSS Configure" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="GPL-3.0-only">
+<tool id="pm_yaml_config" name="PyMuonSuite AIRSS Configure" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="MIT">
     <description>define AIRSS parameters</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
@@ -214,6 +214,8 @@
     </tests>
     <help><![CDATA[
         Creates a YAML configuration file from input parameters.
+
+        Note that while this tool uses the MIT license, PyMuonSuite itself is distributed under GPLv3.
 
       **DFTB+ parameter sets:**
 

--- a/pm_yaml_config/pm_yaml_config.xml
+++ b/pm_yaml_config/pm_yaml_config.xml
@@ -1,4 +1,4 @@
-<tool id="pm_yaml_config" name="PyMuonSuite AIRSS Configure" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01">
+<tool id="pm_yaml_config" name="PyMuonSuite AIRSS Configure" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01" license="GPL-3.0-only">
     <description>define AIRSS parameters</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
@@ -12,7 +12,7 @@
         <token name="@TOOL_CITATION@">
             @software{pymuon-suite,
                 author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and {Muon Spectroscopy Computational Project}},
-                license = {GPL-3.0},
+                license = {GPL-3.0-only},
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
                 version = {v0.2.1},


### PR DESCRIPTION
Add the `license` attribute to all tools. This should now appear alongside citations, requirements etc. at the bottom of the page for each tool.

For `muspinsim...` tools, this was `MIT`. For `pm...` tools, it was `GPL-3.0` but this identifier is deprecated in favour of `GPL-3.0-only`:
https://spdx.org/licenses/GPL-3.0.html
https://spdx.org/licenses/GPL-3.0-only.html

For `cif2cell`, we didn't already have a license recorded in the xml so I checked https://pypi.org/project/cif2cell/

For [pm_dftb_opt](https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools/compare/patrick/92-license-attribute?expand=1#diff-26f80979afa2a3fc5cb7c5488e673e1dc02a3f73600bbd1cfe1882ee4dc95011) the software/tool itself uses GPL3, but some of the parameter sets that can be used with DFTB use https://spdx.org/licenses/CC-BY-SA-4.0.html
e.g.
https://dftb.org/parameters/download/pbc/pbc-0-3-cc
which requires that we "indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License."
I've therefore left the existing disclaimer in the help, but used GPL3 as the `license` attribute seeing as that applies to the tool itself. If someone with more knowledge of licensing thinks another approach would be more suitable, I'm happy to change this.

Closes #92 