### PR TITLE
Add expect_num_outputs to all tests #91

### DIFF
--- a/cif2cell/cif2cell.xml
+++ b/cif2cell/cif2cell.xml
@@ -26,11 +26,11 @@
         <data label="Conversion of $cif_structure.name to .cell" name="out_cell" format="cell" from_work_dir="out.cell" />
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="1">
             <param name="cif_structure" value="Si.cif" ftype="cif" />
             <output name="out_cell" file="Si_out.cell" compare="diff" lines_diff="2" ftype="cell" />
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="cif_structure" value="diamond.cif" ftype="cif" />
             <output name="out_cell" file="diamond_out.cell" compare="diff" lines_diff="2" ftype="cell" />
         </test>

--- a/muspinsim/muspinsim.xml
+++ b/muspinsim/muspinsim.xml
@@ -71,14 +71,14 @@
     <tests>
         <!-- log files have a timestamp on each line, and .dat files vary by machine
                 so use compare="re_match" or "contains" with some generalised test files -->
-        <test>
+        <test expect_num_outputs="2">
             <param name="mu_sim" value="hfine.in" ftype="txt"/>
             <output_collection name="muspinsim_results" type="list">
                 <element name="hfine.dat" file="hfine.dat" ftype="txt" lines_diff="4"/>
             </output_collection>
             <output name="log_out" file="hfine.log" ftype="txt" compare="re_match"/>
         </test>
-        <test>
+        <test expect_num_outputs="2">
             <param name="mu_sim" value="hfine_powder.in" ftype="txt"/>
             <output_collection name="muspinsim_results" type="list">
                 <element name="muspinsim.dat" file="generic_out.dat" ftype="txt" compare="re_match_multiline">
@@ -93,7 +93,7 @@
                 </assert_contents>
             </output>
         </test>
-        <test>
+        <test expect_num_outputs="3">
             <param name="mu_sim" value="fitting.in" ftype="txt"/>
             <param name="mu_exp_in" value="fitting_input.dat" ftype="txt"/>
             <output_collection name="muspinsim_results" type="list">
@@ -106,7 +106,7 @@
             </output>
             <output name="fit_report" file="fitting_fitreport.txt" ftype="txt" lines_diff="4"/>
         </test>
-        <test>
+        <test expect_num_outputs="2">
             <param name="mu_sim" value="multi_out.in" ftype="txt"/>
             <output_collection name="muspinsim_results" type="list">
                 <element name="multi_out_0_0.dat" file="multi_out_0_0.dat" ftype="txt" compare="re_match_multiline">

--- a/muspinsim_config/muspinsim_config.xml
+++ b/muspinsim_config/muspinsim_config.xml
@@ -309,7 +309,7 @@
         <data format="txt" label="muspinsim input file $out_file_prefix" name="out_file" from_work_dir="outfile.in" />
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="1">
             <param name="out_file_prefix" value="test_1"/>
             <param name="spin_preset" value="custom"/>
             <param name="spin" value="H"/>
@@ -321,7 +321,7 @@
             <param name="zeeman_vector" value="2 0 0" />
             <output name="out_file" file="test_1.in" ftype="txt" compare="diff" />
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="out_file_prefix" value="test_2"/>
             <param name="spin_preset" value="e"/>
             <param name="spin_preset" value="mu"/>
@@ -334,7 +334,7 @@
             <param name="temperature" value="1.0" />
             <output name="out_file" file="test_2.in" ftype="txt" compare="diff" />
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="out_file_prefix" value="test_3"/>
             <param name="spin_preset" value="custom"/>
             <param name="spin" value="H"/>
@@ -353,7 +353,7 @@
             <param name="zcw_n" value="20" />
             <output name="out_file" file="test_3.in" ftype="txt" compare="diff" />
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="out_file_prefix" value="test_4"/>
             <param name="spin_preset" value="custom"/>
             <param name="spin" value="F"/>
@@ -383,7 +383,7 @@
             <param name="eul_n" value="10"/>
             <output name="out_file" file="test_4.in" ftype="txt" compare="diff" />
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="out_file_prefix" value="test_5"/>
             <param name="spin_preset" value="mu"/>
             <param name="interaction" value="dissipation"/>

--- a/muspinsim_plot/muspinsim_plot.xml
+++ b/muspinsim_plot/muspinsim_plot.xml
@@ -86,7 +86,7 @@
         </data>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="1">
             <param name="title" value="Temperature Example"/>
             <param name="xlab" value="Time"/>
             <param name="ylab" value="Asymmetry"/>
@@ -109,7 +109,7 @@
                 </assert_contents>
             </output>
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="title" value="Fitting Example"/>
             <param name="xlab" value="Time"/>
             <param name="ylab" value="Asymmetry"/>

--- a/pm_asephonons/pm_asephonons.xml
+++ b/pm_asephonons/pm_asephonons.xml
@@ -64,7 +64,7 @@
         <data label="phonon report for $structure.name" name="phonon_report" format="txt" from_work_dir="phonon_report.txt"/>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="2">
             <param name="structure" value="Si.cell" ftype="cell"/>
             <param name="name" value="Si"/>
             <param name="dftb_set" value="pbc-0-3"/>
@@ -74,7 +74,7 @@
                 </assert_contents>
             </output>
         </test>
-        <test>
+        <test expect_num_outputs="2">
             <param name="structure" value="Si.cif" ftype="cif"/>
             <param name="name" value="Si"/>
             <param name="dftb_set" value="pbc-0-3"/>
@@ -84,7 +84,7 @@
                 </assert_contents>
             </output>
         </test>
-        <test>
+        <test expect_num_outputs="2">
             <param name="structure" value="Si.xyz" ftype="xyz"/>
             <param name="name" value="Si"/>
             <param name="dftb_set" value="pbc-0-3"/>
@@ -94,7 +94,7 @@
                 </assert_contents>
             </output>
         </test>
-        <test>
+        <test expect_num_outputs="2">
             <param name="structure" value="Si.extxyz" ftype="extxyz"/>
             <param name="name" value="Si"/>
             <param name="dftb_set" value="pbc-0-3"/>

--- a/pm_muairss_read/pm_muairss_read.xml
+++ b/pm_muairss_read/pm_muairss_read.xml
@@ -43,12 +43,12 @@
         <data label="Cluster data for $optimisation_results.name" name="cluster_data" format="txt" from_work_dir="$out_folder/*clusters.dat"/>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="2">
             <param name="optimisation_results" value="uep-out.zip" ftype="zip"/>
             <output name="cluster_report" file="clustout-uep.txt" ftype="txt" lines_diff="2"/>
             <output name="cluster_data" file="clustout-uep.dat" ftype="txt"/>
         </test>
-        <test>
+        <test expect_num_outputs="2">
             <param name="optimisation_results" value="dftb-out.zip" ftype="zip"/>
             <output name="cluster_report" file="clustout-dftb.txt" ftype="txt" lines_diff="2"/>
             <output name="cluster_data" file="clustout-dftb.dat" ftype="txt"/>

--- a/pm_symmetry/pm_symmetry.xml
+++ b/pm_symmetry/pm_symmetry.xml
@@ -40,11 +40,11 @@
         <data label="symmetry of $structure.name" name="symmetry_report" format="txt" from_work_dir="out.txt"/>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="1">
             <param name="structure" value="Si.cell" ftype="cell"/>
             <output name="symmetry_report" file="test_out.txt" ftype="txt" compare="re_match_multiline"/>
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="structure" value="Si.cif" ftype="cif"/>
             <output name="symmetry_report" file="test_out.txt" ftype="txt" compare="re_match_multiline"/>
         </test>
@@ -54,7 +54,7 @@
                 <has_text text="TypeError: 'NoneType' object is not subscriptable"/>
             </assert_stderr>
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="structure" value="Si.extxyz" ftype="extxyz"/>
             <output name="symmetry_report" file="test_out.txt" ftype="txt" compare="re_match_multiline"/>
         </test>

--- a/pm_uep_opt/pm_uep_opt.xml
+++ b/pm_uep_opt/pm_uep_opt.xml
@@ -58,7 +58,7 @@
         </data>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="2">
             <param name="testing" value="true"/>
             <param name="muonated_structures" value="muonated.zip" ftype="zip"/>
             <param name="charge_density" value="Si.den_fmt" ftype="txt"/>

--- a/pm_yaml_config/pm_yaml_config.xml
+++ b/pm_yaml_config/pm_yaml_config.xml
@@ -152,7 +152,7 @@
         <data label="Configuration for $general_params.struct_name" name="out_yaml" format="yaml" from_work_dir="output.yaml"/>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="1">
             <section name="general_params">
                 <param name="poisson_r" value="0.8"/>
                 <param name="struct_name" value="Si"/>
@@ -180,7 +180,7 @@
             </section>
             <output name="out_yaml" file="config.yaml" ftype="yaml" delta="100"/>
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <section name="general_params">
             </section>
             <section name="calculator_params">


### PR DESCRIPTION
Added `expect_num_outputs` to all tests where we weren't already using it. Otherwise no changes to the tests themselves.
Closes #91 