### PR TITLE
Single quote text and data variables in command #89

### DIFF
--- a/cif2cell/cif2cell.xml
+++ b/cif2cell/cif2cell.xml
@@ -15,8 +15,8 @@
         <requirement type="package" version="2.0.0a3">cif2cell</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        cif_structure_name=\$(sed 's/ //g' <<< "$cif_structure.name") &&
-        ln -s $cif_structure \$cif_structure_name &&
+        cif_structure_name=\$(sed 's/ //g' <<< '$cif_structure.name') &&
+        ln -s '$cif_structure' \$cif_structure_name &&
         cif2cell -f \$cif_structure_name -p castep -o out.cell
     ]]></command>
     <inputs>

--- a/muspinsim/muspinsim.xml
+++ b/muspinsim/muspinsim.xml
@@ -30,9 +30,9 @@
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
         ## remove spaces in names
-        mu_sim_name=\$(sed 's/ //g' <<< "$mu_sim.name") &&
+        mu_sim_name=\$(sed 's/ //g' <<< '$mu_sim.name') &&
         ## create links
-        ln -s $mu_sim \$mu_sim_name &&
+        ln -s '$mu_sim' \$mu_sim_name &&
         ## grab 'name' field from input file, if it doesn't exist, set name as 'muspinsim'
         mu_out=\$(grep -A1 '^name' \$mu_sim_name | grep -v 'name' | sed -e 's/^[ \t]*//') &&
         fitreport_out=\${mu_out:-"fitting_data"}_fitreport.txt &&
@@ -40,10 +40,10 @@
         log_out=\$(echo \$mu_sim_name | cut -d '.' -f1).log &&
         ## if fitting data required, check if fitting data exists
         ## create symlink and change filepath in input file to point to symlink
-        if grep '^fitting_data' $mu_sim; then
+        if grep '^fitting_data' '$mu_sim'; then
             if [[ '$mu_exp_in.name' != 'None' ]]; then
-                mu_exp_in_name=\$(sed 's/ //g' <<< "$mu_exp_in.name") &&
-                ln -s $mu_exp_in \$mu_exp_in_name &&
+                mu_exp_in_name=\$(sed 's/ //g' <<< '$mu_exp_in.name') &&
+                ln -s '$mu_exp_in' \$mu_exp_in_name &&
                 sed -iE "/^fitting_data/{n;s/([^)]*)/(\"\$mu_exp_in_name\")/g}" \$mu_sim_name;
             else
                 echo "fitting data required, but no experiment data given" && exit 64;

--- a/muspinsim_config/muspinsim_config.xml
+++ b/muspinsim_config/muspinsim_config.xml
@@ -29,8 +29,8 @@
         <requirement type="package" version="@TOOL_VERSION@">muspinsim</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        cp ${__tool_directory__}/sample_fitting_data.dat ./fitting_data.dat &&
-        python ${__tool_directory__}/build_file.py inputs.json
+        cp '${__tool_directory__}/sample_fitting_data.dat' ./fitting_data.dat &&
+        python '${__tool_directory__}/build_file.py' inputs.json
     ]]></command>
     <configfiles>
         <inputs name="inputs" filename="inputs.json" />

--- a/muspinsim_plot/muspinsim_plot.xml
+++ b/muspinsim_plot/muspinsim_plot.xml
@@ -32,7 +32,7 @@
         <requirement type="package" version="@TOOL_VERSION@">matplotlib</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-       python ${__tool_directory__}/generate_plot.py inputs.json
+       python '${__tool_directory__}/generate_plot.py' inputs.json
     ]]></command>
     <configfiles>
         <inputs name="inputs" data_style="paths" filename="inputs.json"/>

--- a/pm_asephonons/pm_asephonons.xml
+++ b/pm_asephonons/pm_asephonons.xml
@@ -29,23 +29,23 @@
         <requirement type="package" version="3.0">zip</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        structure_name_internal="input_structure.$structure.ext" &&
+        structure_name_internal='input_structure.$structure.ext' &&
         touch pho_params.yaml &&
-        ([[ ! -z "$name" ]] && printf "name: $name \n">>pho_params.yaml || ( >&2 echo "name empty" && exit 2)) &&
-        ([[ ! -z "$phonon_kpoint_grid" ]] && ( printf "phonon_kpoint_grid: $phonon_kpoint_grid \n" | sed "s/__ob__/[/g" | sed "s/__cb__/]/g" )>>pho_params.yaml || ( >&2 echo "phonon_kpoint_grid empty" && exit 2)) &&
-        ([[ ! -z "$kpoint_grid" ]] && ( printf "kpoint_grid: $kpoint_grid \n" | sed "s/__ob__/[/g" | sed "s/__cb__/]/g" )>>pho_params.yaml || ( >&2 echo "kpoint_grid empty" && exit 2)) &&
-        ([[ ! -z "$force_tol" ]] && printf "force_tol: $force_tol \n">>pho_params.yaml || ( >&2 echo "force_tol empty" && exit 2)) &&
-        ([[ ! -z "$dftb_set" ]] && printf "dftb_set: $dftb_set \n">>pho_params.yaml || ( >&2 echo "dftb_set empty" && exit 2)) &&
-        ([[ ! -z "$pbc" ]] && printf "pbc: $pbc \n">>pho_params.yaml || ( >&2 echo "pbc empty" && exit 2)) &&
+        ([[ ! -z '$name' ]] && printf 'name: $name \n'>>pho_params.yaml || ( >&2 echo "name empty" && exit 2)) &&
+        ([[ ! -z '$phonon_kpoint_grid' ]] && ( printf 'phonon_kpoint_grid: $phonon_kpoint_grid \n' | sed "s/__ob__/[/g" | sed "s/__cb__/]/g" )>>pho_params.yaml || ( >&2 echo "phonon_kpoint_grid empty" && exit 2)) &&
+        ([[ ! -z '$kpoint_grid' ]] && ( printf 'kpoint_grid: $kpoint_grid \n' | sed "s/__ob__/[/g" | sed "s/__cb__/]/g" )>>pho_params.yaml || ( >&2 echo "kpoint_grid empty" && exit 2)) &&
+        ([[ ! -z '$force_tol' ]] && printf 'force_tol: $force_tol \n'>>pho_params.yaml || ( >&2 echo "force_tol empty" && exit 2)) &&
+        ([[ ! -z '$dftb_set' ]] && printf 'dftb_set: $dftb_set \n'>>pho_params.yaml || ( >&2 echo "dftb_set empty" && exit 2)) &&
+        ([[ ! -z '$pbc' ]] && printf 'pbc: $pbc \n'>>pho_params.yaml || ( >&2 echo "pbc empty" && exit 2)) &&
         printf "force_clean: false \n">>pho_params.yaml &&
-        ln -s $structure \$structure_name_internal &&
+        ln -s '$structure' \$structure_name_internal &&
         cat pho_params.yaml &&
         pm-asephonons \$structure_name_internal pho_params.yaml ; err=\$? &&
         echo "Asephonons output:" &&
         cat asephonons.out &&
         if [ \$err != 0 ] ; then echo "errored" && exit 24 ; fi &&
-        ln -s "${name}_phonons.txt" phonon_report.txt &&
-        zip -r out_zip.zip $name "${name}_phonons.txt" asephonons.out band.out pho_params.yaml
+        ln -s '${name}_phonons.txt' phonon_report.txt &&
+        zip -r out_zip.zip '$name' '${name}_phonons.txt' asephonons.out band.out pho_params.yaml
     ]]></command>
     <inputs>
         <param type="data" name="structure" label="Structure file" format="cell" help="The structure to generate the phonon report from. Accepted file types: cell."/>

--- a/pm_dftb_opt/pm_dftb_opt.xml
+++ b/pm_dftb_opt/pm_dftb_opt.xml
@@ -28,15 +28,15 @@
         <requirement type="package" version="3.0">zip</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        unzip "$muonated_structures" &&
+        unzip '$muonated_structures' &&
         if test -f "params.yaml"; then echo "params.yaml present"; else echo "params.yaml missing" && exit 64; fi
         && if ( test -f input_structure.* ) ; then echo "input structure present"; else echo "input structure missing" && exit 64; fi
-        && out_folder="`python ${__tool_directory__}/get_out_folder.py`" ;
-        bash ${__tool_directory__}/run.sh \$out_folder ;
+        && out_folder="`python '${__tool_directory__}/get_out_folder.py'`" ;
+        bash '${__tool_directory__}/run.sh' \$out_folder ;
         passed=$? &&
         echo \$passed &&
         if [ \$passed == 2 ]; then echo "input file structure is not dftb" && exit 25; elif [ \$passed == 3 ]; then echo "error in parsing dftb file. check log for details" && exit 26; else echo "parse ok"; fi &&
-        if grep -q 'pbc-0-3' params.yaml; then cp ${__tool_directory__}/README-pbc \$out_folder/README; elif grep -q '3ob-3-1' params.yaml; then cp ${__tool_directory__}/README-3ob \$out_folder README; else ( cp ${__tool_directory__}/README-3ob \$out_folder README-3ob && cp ${__tool_directory__}/README-pbc \$out_folder/README-pbc ); fi;
+        if grep -q 'pbc-0-3' params.yaml; then cp '${__tool_directory__}/README-pbc' \$out_folder/README; elif grep -q '3ob-3-1' params.yaml; then cp '${__tool_directory__}/README-3ob' \$out_folder README; else ( cp '${__tool_directory__}/README-3ob' \$out_folder README-3ob && cp '${__tool_directory__}/README-pbc' \$out_folder/README-pbc ); fi;
         zip -r dftb_results.zip \$out_folder params.yaml input_structure.* &&
         find \$out_folder > tree.txt
     ]]></command>

--- a/pm_muairss_read/pm_muairss_read.xml
+++ b/pm_muairss_read/pm_muairss_read.xml
@@ -29,18 +29,18 @@
         <requirement type="package" version="@TOOL_VERSION@">pymuonsuite</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        unzip "$optimisation_results" &&
+        unzip '$optimisation_results' &&
         if test -f "params.yaml"; then echo "params.yaml present"; else echo "params.yaml missing" && exit 64; fi
         && if ( test -f input_structure.* ) ; then echo "input structure present"; else echo "input structure missing" && exit 64; fi
-        && out_folder="`python ${__tool_directory__}/get_out_folder.py`" &&
+        && out_folder="`python '${__tool_directory__}/get_out_folder.py'`" &&
         pm-muairss -t r input_structure.* params.yaml
     ]]></command>
     <inputs>
         <param type="data" name="optimisation_results" label="optimised muonated structures (.zip)" format="zip" help="A zip folder containing a set of optimised muonated structures, the original structure, and a YAML parameter file. See below for the expected folder structure."/>
     </inputs>
     <outputs>
-        <data label="Cluster report for $optimisation_results.name" name="cluster_report" format="txt" from_work_dir="$out_folder/*clusters.txt"/>
-        <data label="Cluster data for $optimisation_results.name" name="cluster_data" format="txt" from_work_dir="$out_folder/*clusters.dat"/>
+        <data label="Cluster report for $optimisation_results.name" name="cluster_report" format="txt" from_work_dir="${out_folder}/*clusters.txt"/>
+        <data label="Cluster data for $optimisation_results.name" name="cluster_data" format="txt" from_work_dir="${out_folder}/*clusters.dat"/>
     </outputs>
     <tests>
         <test>

--- a/pm_muairss_write/pm_muairss_write.xml
+++ b/pm_muairss_write/pm_muairss_write.xml
@@ -30,16 +30,16 @@
         <requirement type="package" version="3.0">zip</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        structure_name_internal="input_structure.$structure.ext" &&
-        ln -s $structure \$structure_name_internal &&
-        ln -s $params params.yaml &&
+        structure_name_internal='input_structure.$structure.ext' &&
+        ln -s '$structure' \$structure_name_internal &&
+        ln -s '$params' params.yaml &&
         #if str($iscastep.iscastep_sel)=="true":
-            castep_param_name=\$(sed 's/ //g' <<< "$castep_param.name") &&
-            ln -s $castep_param \$castep_param_name &&
+            castep_param_name=\$(sed 's/ //g' <<< '$castep_param.name') &&
+            ln -s '$castep_param' \$castep_param_name &&
             sed -i '/^castep_param: /{h;s/:.*/: $castep_param.name/};\${x;/^$/{s//castep_param: $castep_param.name/;H};x}' params.yaml &&
         #end if
         pm-muairss -t w \$structure_name_internal params.yaml &&
-        out_folder="`python ${__tool_directory__}/get_out_folder.py`" &&
+        out_folder="`python '${__tool_directory__}/get_out_folder.py'`" &&
         #if str($iscastep.iscastep_sel)=="true":
             zip -r out_zip.zip \$out_folder params.yaml \$structure_name_internal \$castep_param_name &&
         #else if str($iscastep.iscastep_sel)=="false":

--- a/pm_symmetry/pm_symmetry.xml
+++ b/pm_symmetry/pm_symmetry.xml
@@ -29,8 +29,8 @@
         <requirement type="package" version="@TOOL_VERSION@">pymuonsuite</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        structure_name_internal=\$(sed 's/ /\_/g' <<< "$structure.name") &&
-        ln -s $structure \$structure_name_internal &&
+        structure_name_internal=\$(sed 's/ /\_/g' <<< '$structure.name') &&
+        ln -s '$structure' \$structure_name_internal &&
         pm-symmetry \$structure_name_internal > out.txt
     ]]></command>
     <inputs>

--- a/pm_uep_opt/pm_uep_opt.xml
+++ b/pm_uep_opt/pm_uep_opt.xml
@@ -30,18 +30,18 @@
         <requirement type="package" version="3.0">zip</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        unzip "$muonated_structures" &&
+        unzip '$muonated_structures' &&
         if test -f "params.yaml"; then echo "params.yaml present"; else echo "params.yaml missing" && exit 64; fi &&
         if ( test -f input_structure.* ) ; then echo "input structure present"; else echo "input structure missing" && exit 64; fi &&
-        charge_density_name=\$(sed 's/ //g' <<< "$charge_density.name") &&
-        ln -s $charge_density \$charge_density_name &&
-        x="\$charge_density_name" &&
+        charge_density_name=\$(sed 's/ //g' <<< '$charge_density.name') &&
+        ln -s '$charge_density' \$charge_density_name &&
+        x=\$charge_density_name &&
         echo "calculated seed name \$x" &&
-        ln -s $castep_log "\${x%%.*}.castep" &&
-        out_folder="`python ${__tool_directory__}/get_out_folder.py`" &&
+        ln -s '$castep_log' "\${x%%.*}.castep" &&
+        out_folder="`python '${__tool_directory__}/get_out_folder.py'`" &&
         find \$out_folder -type f -name "*.yaml" | xargs sed -i "s#^chden_path: .*#chden_path: .\/#g" &&
         find \$out_folder -type f -name "*.yaml" | xargs sed -i "s#^chden_seed: .*#chden_seed: \${x%%.*}#g" &&
-        bash ${__tool_directory__}/run.sh \$out_folder &&
+        bash '${__tool_directory__}/run.sh' \$out_folder &&
         zip -r out_zip.zip \$out_folder params.yaml input_structure.* &&
         find \$out_folder > tree.txt
     ]]></command>

--- a/pm_yaml_config/pm_yaml_config.xml
+++ b/pm_yaml_config/pm_yaml_config.xml
@@ -31,42 +31,42 @@
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
         touch outputx.yaml &&
-        ([[ ! -z "$general_params.poisson_r" ]] && printf "poisson_r: $general_params.poisson_r\n">>outputx.yaml || ( >&2 echo "poisson_r empty" && exit 2)) &&
-        ([[ ! -z "$general_params.struct_name" ]] && printf "name: $general_params.struct_name\n">>outputx.yaml || ( >&2 echo "structure name is empty" && exit 2)) &&
-        ([[ ! -z "$general_params.charged" ]] && printf "charged: $general_params.charged\n">>outputx.yaml || ( >&2 echo "charged muon empty" && exit 2)) &&
-        ([[ ! -z "$general_params.geom_steps" ]] && printf "geom_steps: $general_params.geom_steps\n">>outputx.yaml || ( >&2 echo "geom_steps empty" && exit 2)) &&
-        ([[ ! -z "$general_params.vdw_scale" ]] && printf "vdw_scale: $general_params.vdw_scale\n">>outputx.yaml || ( >&2 echo "vdw_scale empty" && exit 2)) &&
-        ([[ ! -z "$calculator_params.calculator_cond.calculator" ]] && printf "calculator: $calculator_params.calculator_cond.calculator\n">>outputx.yaml || ( >&2 echo "calculator unselected" && exit 2)) &&
-        ([[ ! -z "$general_params.geom_force_tol" ]] && printf "geom_force_tol: $general_params.geom_force_tol\n">>outputx.yaml || ( >&2 echo "geom_force_tol empty" && exit 2)) &&
-        ([[ ! -z "$general_params.out_folder" ]] && printf "out_folder: $general_params.out_folder\n">>outputx.yaml || printf "out_folder: muon-airss-out\n">>outputx.yaml) &&
-        ([[ ! -z "$general_params.random_seed" ]] && printf "random_seed: $general_params.random_seed\n">>outputx.yaml || ( echo "random_seed empty")) &&
-        ([[ ! -z "$clustering_params.supercell" ]] && (printf "supercell: $clustering_params.supercell\n" | sed "s/__ob__/[/g" | sed "s/__cb__/]/g" )>>outputx.yaml || ( >&2 echo "supercell empty" && exit 2)) &&
-        ([[ ! -z "$clustering_params.k_points_grid" ]] && (printf "k_points_grid: $clustering_params.k_points_grid\n" | sed "s/__ob__/[/g" | sed "s/__cb__/]/g" ) >>outputx.yaml || ( >&2 echo "k_points_grid empty" && exit 2)) &&
-        ([[ ! -z "$clustering_params.max_scc_steps" ]] && printf "max_scc_steps: $clustering_params.max_scc_steps\n">>outputx.yaml || ( >&2 echo "max_scc_steps empty")) &&
+        ([[ ! -z '$general_params.poisson_r' ]] && printf 'poisson_r: $general_params.poisson_r\n'>>outputx.yaml || ( >&2 echo "poisson_r empty" && exit 2)) &&
+        ([[ ! -z '$general_params.struct_name' ]] && printf 'name: $general_params.struct_name\n'>>outputx.yaml || ( >&2 echo "structure name is empty" && exit 2)) &&
+        ([[ ! -z '$general_params.charged' ]] && printf 'charged: $general_params.charged\n'>>outputx.yaml || ( >&2 echo "charged muon empty" && exit 2)) &&
+        ([[ ! -z '$general_params.geom_steps' ]] && printf 'geom_steps: $general_params.geom_steps\n'>>outputx.yaml || ( >&2 echo "geom_steps empty" && exit 2)) &&
+        ([[ ! -z '$general_params.vdw_scale' ]] && printf 'vdw_scale: $general_params.vdw_scale\n'>>outputx.yaml || ( >&2 echo "vdw_scale empty" && exit 2)) &&
+        ([[ ! -z '$calculator_params.calculator_cond.calculator' ]] && printf 'calculator: $calculator_params.calculator_cond.calculator\n'>>outputx.yaml || ( >&2 echo "calculator unselected" && exit 2)) &&
+        ([[ ! -z '$general_params.geom_force_tol' ]] && printf 'geom_force_tol: $general_params.geom_force_tol\n'>>outputx.yaml || ( >&2 echo "geom_force_tol empty" && exit 2)) &&
+        ([[ ! -z '$general_params.out_folder' ]] && printf 'out_folder: $general_params.out_folder\n'>>outputx.yaml || printf "out_folder: muon-airss-out\n">>outputx.yaml) &&
+        ([[ ! -z '$general_params.random_seed' ]] && printf 'random_seed: $general_params.random_seed\n'>>outputx.yaml || ( echo "random_seed empty")) &&
+        ([[ ! -z '$clustering_params.supercell' ]] && (printf 'supercell: $clustering_params.supercell\n' | sed "s/__ob__/[/g" | sed "s/__cb__/]/g" )>>outputx.yaml || ( >&2 echo "supercell empty" && exit 2)) &&
+        ([[ ! -z '$clustering_params.k_points_grid' ]] && (printf 'k_points_grid: $clustering_params.k_points_grid\n' | sed "s/__ob__/[/g" | sed "s/__cb__/]/g" ) >>outputx.yaml || ( >&2 echo "k_points_grid empty" && exit 2)) &&
+        ([[ ! -z '$clustering_params.max_scc_steps' ]] && printf 'max_scc_steps: $clustering_params.max_scc_steps\n'>>outputx.yaml || ( >&2 echo "max_scc_steps empty")) &&
         #if str($calculator_params.calculator_cond.calculator)=="uep":
-            ([[ ! -z "$calculator_params.calculator_cond.uep_gw_factor" ]] && printf "uep_gw_factor: $calculator_params.calculator_cond.uep_gw_factor\n">>outputx.yaml || ( >&2 echo "uep gaussian width unset" && exit 2)) &&
-            ([[ ! -z "$calculator_params.calculator_cond.uep_chden" ]] && printf "uep_chden: $calculator_params.calculator_cond.uep_chden.value\n">>outputx.yaml || echo "den_fmt path unset") &&
+            ([[ ! -z '$calculator_params.calculator_cond.uep_gw_factor' ]] && printf 'uep_gw_factor: $calculator_params.calculator_cond.uep_gw_factor\n'>>outputx.yaml || ( >&2 echo "uep gaussian width unset" && exit 2)) &&
+            ([[ ! -z '$calculator_params.calculator_cond.uep_chden' ]] && printf 'uep_chden: $calculator_params.calculator_cond.uep_chden.value\n'>>outputx.yaml || echo "den_fmt path unset") &&
         #else if str($calculator_params.calculator_cond.calculator)=="CASTEP":
-            ([[ ! -z "$calculator_params.calculator_cond.castep_command" ]] && printf "castep_command: $calculator_params.calculator_cond.castep_command\n">>outputx.yaml || echo "CASTEP command unset") &&
-            ([[ ! -z "$calculator_params.calculator_cond.castep_param" ]] && printf "castep_param: $calculator_params.calculator_cond.castep_param\n">>outputx.yaml || echo "CASTEP param unset") &&
-            ([[ ! -z "$calculator_params.calculator_cond.mu_symbol" ]] && printf "mu_symbol: $calculator_params.calculator_cond.mu_symbol\n">>outputx.yaml || echo "mu symbol unset") &&
+            ([[ ! -z '$calculator_params.calculator_cond.castep_command' ]] && printf 'castep_command: $calculator_params.calculator_cond.castep_command\n'>>outputx.yaml || echo "CASTEP command unset") &&
+            ([[ ! -z '$calculator_params.calculator_cond.castep_param' ]] && printf 'castep_param: $calculator_params.calculator_cond.castep_param\n'>>outputx.yaml || echo "CASTEP param unset") &&
+            ([[ ! -z '$calculator_params.calculator_cond.mu_symbol' ]] && printf 'mu_symbol: $calculator_params.calculator_cond.mu_symbol\n'>>outputx.yaml || echo "mu symbol unset") &&
         #else if str($calculator_params.calculator_cond.calculator)=="dftb+":
-            ([[ ! -z "$calculator_params.calculator_cond.dftb_set" ]] && printf "dftb_set: $calculator_params.calculator_cond.dftb_set\n">>outputx.yaml || ( >&2 echo "dftb parameter set unselected" && exit 2)) &&
-            ([[ ! -z "$calculator_params.calculator_cond.dftb_pbc" ]] && printf "dftb_pbc: $calculator_params.calculator_cond.dftb_pbc\n">>outputx.yaml || echo "dftb periodic boundary condition unselected") &&
+            ([[ ! -z '$calculator_params.calculator_cond.dftb_set' ]] && printf 'dftb_set: $calculator_params.calculator_cond.dftb_set\n'>>outputx.yaml || ( >&2 echo "dftb parameter set unselected" && exit 2)) &&
+            ([[ ! -z '$calculator_params.calculator_cond.dftb_pbc' ]] && printf 'dftb_pbc: $calculator_params.calculator_cond.dftb_pbc\n'>>outputx.yaml || echo "dftb periodic boundary condition unselected") &&
         #else if str($calculator_params.calculator_cond.calculator)=="all":
-            ([[ ! -z "$calculator_params.calculator_cond.uep_gw_factor" ]] && printf "uep_gw_factor: $calculator_params.calculator_cond.uep_gw_factor\n">>outputx.yaml || echo "uep gaussian width unset") &&
-            ([[ ! -z "$calculator_params.calculator_cond.uep_chden" ]] && printf "uep_chden: $calculator_params.calculator_cond.uep_chden\n">>outputx.yaml || echo "den_fmt path unset") &&
-            ([[ ! -z "$calculator_params.calculator_cond.castep_command" ]] && printf "castep_command: $calculator_params.calculator_cond.castep_command\n">>outputx.yaml || echo "CASTEP command unset") &&
-            ([[ ! -z "$calculator_params.calculator_cond.castep_param" ]] && printf "castep_param: $calculator_params.calculator_cond.castep_param\n">>outputx.yaml || echo "CASTEP param unset") &&
-            ([[ ! -z "$calculator_params.calculator_cond.mu_symbol" ]] && printf "mu_symbol: $calculator_params.calculator_cond.mu_symbol\n">>outputx.yaml || echo "mu symbol unset") &&
-            ([[ ! -z "$calculator_params.calculator_cond.mu_symbol" ]] && printf "dftb_set: $calculator_params.calculator_cond.dftb_set\n">>outputx.yaml || echo "dftb parameter set unselected") &&
-            ([[ ! -z "$calculator_params.calculator_cond.dftb_pbc" ]] && printf "dftb_pbc: $calculator_params.calculator_cond.dftb_pbc\n">>outputx.yaml || echo "dftb periodic boundary condition unselected") &&
+            ([[ ! -z '$calculator_params.calculator_cond.uep_gw_factor' ]] && printf 'uep_gw_factor: $calculator_params.calculator_cond.uep_gw_factor\n'>>outputx.yaml || echo "uep gaussian width unset") &&
+            ([[ ! -z '$calculator_params.calculator_cond.uep_chden' ]] && printf 'uep_chden: $calculator_params.calculator_cond.uep_chden\n'>>outputx.yaml || echo "den_fmt path unset") &&
+            ([[ ! -z '$calculator_params.calculator_cond.castep_command' ]] && printf 'castep_command: $calculator_params.calculator_cond.castep_command\n'>>outputx.yaml || echo "CASTEP command unset") &&
+            ([[ ! -z '$calculator_params.calculator_cond.castep_param' ]] && printf 'castep_param: $calculator_params.calculator_cond.castep_param\n'>>outputx.yaml || echo "CASTEP param unset") &&
+            ([[ ! -z '$calculator_params.calculator_cond.mu_symbol' ]] && printf 'mu_symbol: $calculator_params.calculator_cond.mu_symbol\n'>>outputx.yaml || echo "mu symbol unset") &&
+            ([[ ! -z '$calculator_params.calculator_cond.mu_symbol' ]] && printf 'dftb_set: $calculator_params.calculator_cond.dftb_set\n'>>outputx.yaml || echo "dftb parameter set unselected") &&
+            ([[ ! -z '$calculator_params.calculator_cond.dftb_pbc' ]] && printf 'dftb_pbc: $calculator_params.calculator_cond.dftb_pbc\n'>>outputx.yaml || echo "dftb periodic boundary condition unselected") &&
         #end if
-        ([[ ! -z "$clustering_params.clustering.clustering_method " ]] && printf "clustering_method: $clustering_params.clustering.clustering_method\n">>outputx.yaml || ( echo "clustering method unselected" && exit 2)) &&
+        ([[ ! -z '$clustering_params.clustering.clustering_method' ]] && printf 'clustering_method: $clustering_params.clustering.clustering_method\n'>>outputx.yaml || ( echo "clustering method unselected" && exit 2)) &&
         #if str($clustering_params.clustering.clustering_method)=="hier":
-            ([[ ! -z "$clustering_params.clustering.clustering_hier_t" ]] && printf "clustering_hier_t: $clustering_params.clustering.clustering_hier_t\n">>outputx.yaml || echo "clustering_hier_t unset") &&
+            ([[ ! -z '$clustering_params.clustering.clustering_hier_t' ]] && printf 'clustering_hier_t: $clustering_params.clustering.clustering_hier_t\n'>>outputx.yaml || echo "clustering_hier_t unset") &&
         #else if str($clustering_params.clustering.clustering_method)=="kmeans":
-            ([[ ! -z "$clustering_params.clustering.clustering_kmeans_k" ]] && printf "clustering_kmeans_k: $clustering_params.clustering.clustering_kmeans_k\n">>outputx.yaml || echo "clustering_kmeans_k unset") &&
+            ([[ ! -z '$clustering_params.clustering.clustering_kmeans_k' ]] && printf 'clustering_kmeans_k: $clustering_params.clustering.clustering_kmeans_k\n'>>outputx.yaml || echo "clustering_kmeans_k unset") &&
         #end if
         ln -s outputx.yaml output.yaml
     ]]></command>


### PR DESCRIPTION
In accordance with https://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html#command-formatting use single quotes for text parameters, input and output files. Details of implementation:
- Simple cases are formatted as `'$var.name'`
- Non-Cheetah variables (those using an escaped `\$` are not quoted and left as `\$var_name`
- Variables used as part of longer strings are formatted as `'${name}_phonons.txt'`
- Boolean or select parameters are not quoted as they can only take certain values we've set in the wrapper `#if str($calculator_params.calculator_cond.calculator)=="uep":`
- Variables accessed in the `data` `label` or `from_work_dir` tags are not quoted
- Other instances of single/double quotes were left as they were

Closes #89 