### PR TITLE
Add validators for supercell and k_points_grid #87

### DIFF
--- a/pm_yaml_config/pm_yaml_config.xml
+++ b/pm_yaml_config/pm_yaml_config.xml
@@ -143,8 +143,12 @@
                     <param type="integer" argument="clustering_kmeans_k" name="clustering_kmeans_k" value="4" optional="true" label="Number of clusters for k-means clustering"/>
                 </when>
             </conditional>
-            <param type="integer" argument="supercell" name="supercell" value="1" label="Supercell" multiple="true" help="Supercell size and shape to use. This can either be a single int, a list of three integers or a 3x3 matrix of integers. For a single number a diagonal matrix will be generated with the integer repeated on the diagonals. For a list of three numbers a diagonal matrix will be generated where the diagonal elements are set to the list. A matrix will be used directly as is. Default is a 3x3 identity matrix."/>
-            <param type="text" argument="k_points_grid" name="k_points_grid" value="[1,1,1]" label="K-points grid" multiple="true" help="List of three integer k-points. Default is [1,1,1]."/>
+            <param type="text" argument="supercell" name="supercell" value="1" label="Supercell" help="Supercell size and shape to use. This can either be a single int, a list of three integers or a 3x3 matrix of integers. For a single number a diagonal matrix will be generated with the integer repeated on the diagonals. For a list of three numbers a diagonal matrix will be generated where the diagonal elements are set to the list. A matrix will be used directly as is. Default is a 3x3 identity matrix.">
+                <validator type="regex" message="Input should only contain whitespace, '[', ']', ',' and digits.">^[\s\d,\[\]]+$</validator>
+            </param>
+            <param type="text" argument="k_points_grid" name="k_points_grid" value="[1,1,1]" label="K-points grid" help="List of three integer k-points. Default is [1,1,1].">
+                <validator type="regex" message="Input should only contain whitespace, '[', ']', ',' and digits.">^[\s\d,\[\]]+$</validator>
+            </param>
             <param type="integer" argument="max_scc_steps" name="max_scc_steps" value="200" optional="true" label="Max SCC steps" help="If applicable, max number of SCC steps to perform before giving up. Default is 200 for DFTB+ and 30 for CASTEP."/>
         </section>
     </inputs>
@@ -188,6 +192,24 @@
             <section name="clustering_params">
             </section>
             <output name="out_yaml" file="config-default.yaml" ftype="yaml" delta="100"/>
+        </test>
+        <test expect_failure="true">
+            <section name="general_params">
+            </section>
+            <section name="calculator_params">
+            </section>
+            <section name="clustering_params">
+                <param name="supercell" value="bad format"/>
+            </section>
+        </test>
+        <test expect_failure="true">
+            <section name="general_params">
+            </section>
+            <section name="calculator_params">
+            </section>
+            <section name="clustering_params">
+                <param name="k_points_grid" value="bad format"/>
+            </section>
         </test>
     </tests>
     <help><![CDATA[


### PR DESCRIPTION
Changed the type of `supercell` to `text` so that lists and matrices can be submitted, as the help text suggests.

Added a `regex` validator to both `supercell` and `k_points_grid` which allows only the characters needed to build a matrix:
- whitespace
- digits
- [
- ]
- ,

Note that this technically isn't sufficient to validate the input: an input of `] , 000000 , [` would pass the validator despite obviously not being a integer, list or matrix. In the issue discussion, simple validation was deemed sufficient for these purposes. It is worth noting however that because all this tool (`pm_yaml_config`) does is generate a config file, the failure that input would cause wouldn't happen until running `pm_muairss_write`. This is worth considering in the context of #99 

Finally added tests that are expected to fail when bad inputs provided.

Closes #87 