### PR TITLE
Add description tag for muspinsim_plot #104

### DIFF
--- a/muspinsim_plot/muspinsim_plot.xml
+++ b/muspinsim_plot/muspinsim_plot.xml
@@ -1,4 +1,5 @@
 <tool id="muspinsim_plot" name="MuSpinSim Plot" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.01">
+    <description>plot values generated from MuSpinSim</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
         <token name="@TOOL_VERSION@">3.5.1</token>


### PR DESCRIPTION
Add a simple description to `muspinsim_plot/muspinsim_plot.xml` to match the other tools, and conform with best practice.

Closes #104 