### PR TITLE
Add argument to cif2cell and remove redundant names #103

### DIFF
--- a/cif2cell/cif2cell.xml
+++ b/cif2cell/cif2cell.xml
@@ -15,23 +15,23 @@
         <requirement type="package" version="2.0.0a3">cif2cell</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        cif_structure_name=\$(sed 's/ //g' <<< "$cif_structure.name") &&
-        ln -s $cif_structure \$cif_structure_name &&
-        cif2cell -f \$cif_structure_name -p castep -o out.cell
+        file_name=\$(sed 's/ //g' <<< "$file.name") &&
+        ln -s $file \$file_name &&
+        cif2cell -f \$file_name -p castep -o out.cell
     ]]></command>
     <inputs>
-        <param type="data" name="cif_structure" format="cif" label="Structure file to Convert (.cif)" />
+        <param type="data" argument="--file" format="cif" label="Structure file to Convert (.cif)" />
     </inputs>
     <outputs>
-        <data label="Conversion of $cif_structure.name to .cell" name="out_cell" format="cell" from_work_dir="out.cell" />
+        <data label="Conversion of $file.name to .cell" name="out_cell" format="cell" from_work_dir="out.cell" />
     </outputs>
     <tests>
         <test expect_num_outputs="1">
-            <param name="cif_structure" value="Si.cif" ftype="cif" />
+            <param name="file" value="Si.cif" ftype="cif" />
             <output name="out_cell" file="Si_out.cell" compare="diff" lines_diff="2" ftype="cell" />
         </test>
         <test expect_num_outputs="1">
-            <param name="cif_structure" value="diamond.cif" ftype="cif" />
+            <param name="file" value="diamond.cif" ftype="cif" />
             <output name="out_cell" file="diamond_out.cell" compare="diff" lines_diff="2" ftype="cell" />
         </test>
     </tests>

--- a/pm_yaml_config/pm_yaml_config.xml
+++ b/pm_yaml_config/pm_yaml_config.xml
@@ -32,7 +32,7 @@
     <command detect_errors="exit_code"><![CDATA[
         touch outputx.yaml &&
         ([[ ! -z "$general_params.poisson_r" ]] && printf "poisson_r: $general_params.poisson_r\n">>outputx.yaml || ( >&2 echo "poisson_r empty" && exit 2)) &&
-        ([[ ! -z "$general_params.struct_name" ]] && printf "name: $general_params.struct_name\n">>outputx.yaml || ( >&2 echo "structure name is empty" && exit 2)) &&
+        ([[ ! -z "$general_params.name" ]] && printf "name: $general_params.name\n">>outputx.yaml || ( >&2 echo "structure name is empty" && exit 2)) &&
         ([[ ! -z "$general_params.charged" ]] && printf "charged: $general_params.charged\n">>outputx.yaml || ( >&2 echo "charged muon empty" && exit 2)) &&
         ([[ ! -z "$general_params.geom_steps" ]] && printf "geom_steps: $general_params.geom_steps\n">>outputx.yaml || ( >&2 echo "geom_steps empty" && exit 2)) &&
         ([[ ! -z "$general_params.vdw_scale" ]] && printf "vdw_scale: $general_params.vdw_scale\n">>outputx.yaml || ( >&2 echo "vdw_scale empty" && exit 2)) &&
@@ -72,58 +72,58 @@
     ]]></command>
     <inputs>
         <section name="general_params" expanded="true" title="General Parameters">
-            <param type="float" name="poisson_r" argument="poisson_r" value="0.8" label="Poisson radius" help=" Poisson sphere radius to use for random generation. No two starting muon positions will be closer than this distance. Smaller values make for bigger structure sets."/>
-            <param type="text" argument="struct_name" name="struct_name" value="struct" label="Name" help="Name of the structure. This name will be postfixed with a unique number, e.g. struct_001 for each generated structure."/>
-            <param type="select" argument="charged" name="charged" label="Charged muon" value="true" help="If true, the muon will be considered charged instead of a muonium with an accompanying electron. Must be true for UEP calculations.">
+            <param type="float" argument="poisson_r" value="0.8" label="Poisson radius" help=" Poisson sphere radius to use for random generation. No two starting muon positions will be closer than this distance. Smaller values make for bigger structure sets."/>
+            <param type="text" argument="name" value="struct" label="Name" help="Name of the structure. This name will be postfixed with a unique number, e.g. struct_001 for each generated structure."/>
+            <param type="select" argument="charged" label="Charged muon" value="true" help="If true, the muon will be considered charged instead of a muonium with an accompanying electron. Must be true for UEP calculations.">
                 <option value="true">true</option>
                 <option value="false">false</option>
             </param>
-            <param type="integer" argument="geom_steps" name="geom_steps" value="30" label="Geometry optimization steps" help="Maximum number of geometry optimisation steps."/>
-            <param type="float" argument="vdw_scale" name="vdw_scale" value="0.5" label="Van der Waals scale" help="Van der Waals scaling factor to use when generating muon sites to avoid existing atoms. Smaller values will allow muons to get closer to the other ions."/>
-            <param type="text" argument="out_folder" optional="true" name="out_folder" value="muon-airss-out" label="Output folder name" help="Name to call the output folder used to store the files that the script generates."/>
-            <param type="float" argument="geom_force_tol" name="geom_force_tol" value="0.05" label="Geometry optimization tolerance" help="Tolerance on geometry optimisation in units of eV/Å."/>
-            <param type="integer" argument="random_seed" name="random_seed" label="Random Seed" optional="true" help="Random seed for pymuonsuite."/>
+            <param type="integer" argument="geom_steps" value="30" label="Geometry optimization steps" help="Maximum number of geometry optimisation steps."/>
+            <param type="float" argument="vdw_scale" value="0.5" label="Van der Waals scale" help="Van der Waals scaling factor to use when generating muon sites to avoid existing atoms. Smaller values will allow muons to get closer to the other ions."/>
+            <param type="text" argument="out_folder" optional="true" value="muon-airss-out" label="Output folder name" help="Name to call the output folder used to store the files that the script generates."/>
+            <param type="float" argument="geom_force_tol" value="0.05" label="Geometry optimization tolerance" help="Tolerance on geometry optimisation in units of eV/Å."/>
+            <param type="integer" argument="random_seed" label="Random Seed" optional="true" help="Random seed for pymuonsuite."/>
         </section>
         <section name="calculator_params" expanded="true" title="Calculator parameters">
             <conditional name="calculator_cond">
-                <param type="select" display="radio" label="Optimization calculator" argument="calculator" name="calculator" value="uep" help="Calculator to generate structure files for. Must be a single word or a comma seperated list of values. Currently supported calculators are CASTEP, DFTB+ and UEP. Can also select 'all' to generate files for all calculators.">
+                <param type="select" display="radio" label="Optimization calculator" argument="calculator" value="uep" help="Calculator to generate structure files for. Must be a single word or a comma seperated list of values. Currently supported calculators are CASTEP, DFTB+ and UEP. Can also select 'all' to generate files for all calculators.">
                     <option value="uep">UEP</option>
                     <option value="castep">CASTEP</option>
                     <option value="dftb+">DFTB+</option>
                     <option value="all">all</option>
                 </param>
                 <when value="uep">
-                    <param type="float" argument="uep_gw_factor" name="uep_gw_factor" optional="true" value="5.0" label="Gaussian width factor" help="Gaussian width factor for UEP calculation. Higher values will make the potential of atomic nuclei closer to the point-like approximation but may introduce artifacts."/>
-                    <param type="text" argument="uep_chden" name="uep_chden" optional="true" label="Path to .den_fmt and .castep files" help="Name of the .den_fmt file containing the electronic density for an Unperturbed Electrostatic Potential optimisation. The corresponding .castep file must be with the same seedname. Only required for use outside Muon Galaxy"/>
+                    <param type="float" argument="uep_gw_factor" optional="true" value="5.0" label="Gaussian width factor" help="Gaussian width factor for UEP calculation. Higher values will make the potential of atomic nuclei closer to the point-like approximation but may introduce artifacts."/>
+                    <param type="text" argument="uep_chden" optional="true" label="Path to .den_fmt and .castep files" help="Name of the .den_fmt file containing the electronic density for an Unperturbed Electrostatic Potential optimisation. The corresponding .castep file must be with the same seedname. Only required for use outside Muon Galaxy"/>
                 </when>
                 <when value="castep">
-                    <param type="text" argument="castep_command" name="castep_command" optional="true" value="castep.serial" label="CASTEP command" help="Command to use to run CASTEP."/>
-                    <param type="text" argument="castep_param" name="castep_param" optional="true" label="PARAM path" help="File path to the CASTEP parameter file."/>
-                    <param type="text" argument="mu_symbol" name="mu_symbol" optional="true" label="Muon symbol" value="H:mu" help="The symbol to use for the muon when writing out the CASTEP custom species."/>
+                    <param type="text" argument="castep_command" optional="true" value="castep.serial" label="CASTEP command" help="Command to use to run CASTEP."/>
+                    <param type="text" argument="castep_param" optional="true" label="PARAM path" help="File path to the CASTEP parameter file."/>
+                    <param type="text" argument="mu_symbol" optional="true" label="Muon symbol" value="H:mu" help="The symbol to use for the muon when writing out the CASTEP custom species."/>
                 </when>
                 <when value="dftb+">
-                    <param type="select" argument="dftb_set" name="dftb_set" optional="true" value="3ob-3-1" label="DFTB parameter set" help="The parameter set to use for DFTB+. Currently supported are: 3ob-3-1 and pbc-0-3. See help section at the bottom of the page for details.">
+                    <param type="select" argument="dftb_set" optional="true" value="3ob-3-1" label="DFTB parameter set" help="The parameter set to use for DFTB+. Currently supported are: 3ob-3-1 and pbc-0-3. See help section at the bottom of the page for details.">
                         <option value="3ob-3-1" selected="true">3ob-3-1</option>
                         <option value="pbc-0-3">pbc-0-3</option>
                     </param>
                     <param type="text" argument="dftb_optionals" name="dftb_optionals" value="[]" optional="true" label="DFTB optional files" help="Additional optional json files to activate for DFTBArgs (for example, dftd3.json will use DFTD3 dispersion forces for 3ob-3-1 if DFTB+ has been compiled to support them)."/>
-                    <param type="select" argument="dftb_pbc" name="dftb_pbc" optional="true" value="true" label="Use periodic boundary conditions" help="Whether to turn on periodic boundary conditions in DFTB+.">
+                    <param type="select" argument="dftb_pbc" optional="true" value="true" label="Use periodic boundary conditions" help="Whether to turn on periodic boundary conditions in DFTB+.">
                         <option value="true" selected="true">true</option>
                         <option value="false">false</option>
                     </param>
                 </when>
                 <when value="all">
-                    <param type="float" argument="uep_gw_factor" name="uep_gw_factor" optional="true" value="5.0" label="Gaussian width factor" help="Gaussian width factor for UEP calculation. Higher values will make the potential of atomic nuclei closer to the point-like approximation but may introduce artifacts."/>
-                    <param type="text" argument="uep_chden" name="uep_chden" optional="true" label="Path to .den_fmt and CASTEP files" help="Name of the .den_fmt file containing the electronic density for an Unperturbed Electrostatic Potential optimisation. The corresponding .castep file must be with the same seedname. Only required for use outside Muon Galaxy"/>
-                    <param type="text" argument="castep_command" name="castep_command" optional="true" value="castep.serial" label="CASTEP command" help="Command to use to run CASTEP."/>
-                    <param type="text" argument="castep_param" name="castep_param" optional="true" label="PARAM path" help="File path to the CASTEP parameter file."/>
-                    <param type="text" argument="mu_symbol" name="mu_symbol" optional="true" label="Muon symbol" value="H:mu" help="The symbol to use for the muon when writing out the CASTEP custom species."/>
-                    <param type="select" argument="dftb_set" name="dftb_set" optional="true" value="3ob-3-1" label="DFTB parameter set" help="The parameter set to use for DFTB+. Currently supported are: 3ob-3-1 and pbc-0-3. See help section at the bottom of the page for details.">
+                    <param type="float" argument="uep_gw_factor" optional="true" value="5.0" label="Gaussian width factor" help="Gaussian width factor for UEP calculation. Higher values will make the potential of atomic nuclei closer to the point-like approximation but may introduce artifacts."/>
+                    <param type="text" argument="uep_chden" optional="true" label="Path to .den_fmt and CASTEP files" help="Name of the .den_fmt file containing the electronic density for an Unperturbed Electrostatic Potential optimisation. The corresponding .castep file must be with the same seedname. Only required for use outside Muon Galaxy"/>
+                    <param type="text" argument="castep_command" optional="true" value="castep.serial" label="CASTEP command" help="Command to use to run CASTEP."/>
+                    <param type="text" argument="castep_param" optional="true" label="PARAM path" help="File path to the CASTEP parameter file."/>
+                    <param type="text" argument="mu_symbol" optional="true" label="Muon symbol" value="H:mu" help="The symbol to use for the muon when writing out the CASTEP custom species."/>
+                    <param type="select" argument="dftb_set" optional="true" value="3ob-3-1" label="DFTB parameter set" help="The parameter set to use for DFTB+. Currently supported are: 3ob-3-1 and pbc-0-3. See help section at the bottom of the page for details.">
                         <option value="3ob-3-1" selected="true">3ob-3-1</option>
                         <option value="pbc-0-3">pbc-0-3</option>
                     </param>
                     <param type="text" argument="dftb_optionals" name="dftb_optionals" value="[]" optional="true" label="DFTB optional files" help="Additional optional json files to activate for DFTBArgs (for example, dftd3.json will use DFTD3 dispersion forces for 3ob-3-1 if DFTB+ has been compiled to support them)."/>
-                    <param type="select" argument="dftb_pbc" name="dftb_pbc" optional="true" value="true" label="Use periodic boundary conditions" help="Whether to turn on periodic boundary conditions in DFTB+.">
+                    <param type="select" argument="dftb_pbc" optional="true" value="true" label="Use periodic boundary conditions" help="Whether to turn on periodic boundary conditions in DFTB+.">
                         <option value="true" selected="true">true</option>
                         <option value="false">false</option>
                     </param>
@@ -132,30 +132,30 @@
         </section>
         <section name="clustering_params" expanded="true" title="Clustering Parameters">
             <conditional name="clustering">
-                <param type="select" argument="clustering_method" name="clustering_method" label="Clustering method" value="hier">
+                <param type="select" argument="clustering_method" label="Clustering method" value="hier">
                     <option value="hier">hierarchical</option>
                     <option value="kmeans">k-means</option>
                 </param>
                 <when value="hier">
-                    <param type="float" argument="clustering_hier_t" name="clustering_hier_t" value="0.3" optional="true" label="t parameter for hierarchical clustering"/>
+                    <param type="float" argument="clustering_hier_t" value="0.3" optional="true" label="t parameter for hierarchical clustering"/>
                 </when>
                 <when value="kmeans">
-                    <param type="integer" argument="clustering_kmeans_k" name="clustering_kmeans_k" value="4" optional="true" label="Number of clusters for k-means clustering"/>
+                    <param type="integer" argument="clustering_kmeans_k" value="4" optional="true" label="Number of clusters for k-means clustering"/>
                 </when>
             </conditional>
-            <param type="integer" argument="supercell" name="supercell" value="1" label="Supercell" multiple="true" help="Supercell size and shape to use. This can either be a single int, a list of three integers or a 3x3 matrix of integers. For a single number a diagonal matrix will be generated with the integer repeated on the diagonals. For a list of three numbers a diagonal matrix will be generated where the diagonal elements are set to the list. A matrix will be used directly as is. Default is a 3x3 identity matrix."/>
-            <param type="text" argument="k_points_grid" name="k_points_grid" value="[1,1,1]" label="K-points grid" multiple="true" help="List of three integer k-points. Default is [1,1,1]."/>
-            <param type="integer" argument="max_scc_steps" name="max_scc_steps" value="200" optional="true" label="Max SCC steps" help="If applicable, max number of SCC steps to perform before giving up. Default is 200 for DFTB+ and 30 for CASTEP."/>
+            <param type="integer" argument="supercell" value="1" label="Supercell" multiple="true" help="Supercell size and shape to use. This can either be a single int, a list of three integers or a 3x3 matrix of integers. For a single number a diagonal matrix will be generated with the integer repeated on the diagonals. For a list of three numbers a diagonal matrix will be generated where the diagonal elements are set to the list. A matrix will be used directly as is. Default is a 3x3 identity matrix."/>
+            <param type="text" argument="k_points_grid" value="[1,1,1]" label="K-points grid" multiple="true" help="List of three integer k-points. Default is [1,1,1]."/>
+            <param type="integer" argument="max_scc_steps" value="200" optional="true" label="Max SCC steps" help="If applicable, max number of SCC steps to perform before giving up. Default is 200 for DFTB+ and 30 for CASTEP."/>
         </section>
     </inputs>
     <outputs>
-        <data label="Configuration for $general_params.struct_name" name="out_yaml" format="yaml" from_work_dir="output.yaml"/>
+        <data label="Configuration for $general_params.name" name="out_yaml" format="yaml" from_work_dir="output.yaml"/>
     </outputs>
     <tests>
         <test expect_num_outputs="1">
             <section name="general_params">
                 <param name="poisson_r" value="0.8"/>
-                <param name="struct_name" value="Si"/>
+                <param name="name" value="Si"/>
                 <param name="charged" value="true"/>
                 <param name="geom_steps" value="300"/>
                 <param name="vwd_scale" value="0.25"/>


### PR DESCRIPTION
# cif2cell
Rename `name="cif_structure"` to `argument="--file"` (implicitly `name="file"`) to match the command line option of cif2cell

# py_yaml_config
Rename `struct_name` to `name` to be consistent with the actual key used in the yaml output.
Remove all redundant `name="abc"`
Did not change `dftb_optionals` as that isn't even written to the yaml, and should be addressed by #106 

Closes #103