### PR TITLE
Update version and citation for PyMuonSuite #83

### DIFF
--- a/pm_asephonons/pm_asephonons.xml
+++ b/pm_asephonons/pm_asephonons.xml
@@ -1,18 +1,21 @@
-<tool id="pm_asephonons" name="PyMuonSuite Phonons" version="0.1.1" python_template_version="3.5" profile="22.05" license="MIT">
+<tool id="pm_asephonons" name="PyMuonSuite Phonons" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.05" license="MIT">
     <description>calculate phonons using ASE and DFTB+</description>
     <macros>
+        <!-- version of underlying tool (PEP 440) -->
+        <token name="@TOOL_VERSION@">0.2.3</token>
+        <!-- version of this tool wrapper (integer) -->
+        <token name="@WRAPPER_VERSION@">0</token>
         <!-- citation should be updated with every underlying tool version -->
         <!-- typical fields to update are version, month, year, and doi -->
         <token name="@PYMUONSUITE_CITATION@">
-            @software{pymuon-suite,
-                author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and {Muon Spectroscopy Computational Project}},
-                license = {GPL-3.0-only},
+            @software{Sturniolo_pymuon-suite_2022,
+                author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and Mudaraddi, Anish and {Muon Spectroscopy Computational Project}},
+                license = {GPL-3.0},
+                month = {8},
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
-                version = {v0.2.1},
-                month = {2},
-                year = {2022},
-                doi = {}
+                version = {v0.2.3},
+                year = {2022}
             }
         </token>
         <import>muon_macros.xml</import>
@@ -24,7 +27,7 @@
     </creator>
     <requirements>
         <!-- note versioning is different due to multiple dependencies -->
-        <requirement type="package" version="0.2.1">pymuonsuite</requirement>
+        <requirement type="package" version="@TOOL_VERSION@">pymuonsuite</requirement>
         <requirement type="package" version="21.2">dftbplus</requirement>
         <requirement type="package" version="1.22.4">numpy</requirement> <!-- pinned due to numpy/ASE/DFTB+ incompatibility https://github.com/dftbplus/dftbplus/issues/1064 -->
         <requirement type="package" version="3.0">zip</requirement>

--- a/pm_asephonons/pm_asephonons.xml
+++ b/pm_asephonons/pm_asephonons.xml
@@ -15,6 +15,7 @@
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
                 version = {v0.2.3},
+                doi = {10.5281/zenodo.7025644},
                 year = {2022}
             }
         </token>

--- a/pm_dftb_opt/pm_dftb_opt.xml
+++ b/pm_dftb_opt/pm_dftb_opt.xml
@@ -15,6 +15,7 @@
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
                 version = {v0.2.3},
+                doi = {10.5281/zenodo.7025644},
                 year = {2022}
             }
         </token>

--- a/pm_dftb_opt/pm_dftb_opt.xml
+++ b/pm_dftb_opt/pm_dftb_opt.xml
@@ -1,18 +1,21 @@
-<tool id="pm_dftb_opt" name="PyMuonSuite AIRSS DFTB+ Optimise" version="0.1.1" python_template_version="3.5" profile="22.05" license="MIT">
+<tool id="pm_dftb_opt" name="PyMuonSuite AIRSS DFTB+ Optimise" version="@TOOL_VERSION@+galaxy@WRAPPER_VERSION@" python_template_version="3.5" profile="22.05" license="MIT">
     <description>run DFTB+ optimisation</description>
     <macros>
+        <!-- version of underlying tool (PEP 440) -->
+        <token name="@TOOL_VERSION@">0.2.3</token>
+        <!-- version of this tool wrapper (integer) -->
+        <token name="@WRAPPER_VERSION@">0</token>
         <!-- citation should be updated with every underlying tool version -->
         <!-- typical fields to update are version, month, year, and doi -->
         <token name="@PYMUONSUITE_CITATION@">
-            @software{pymuon-suite,
-                author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and {Muon Spectroscopy Computational Project}},
-                license = {GPL-3.0-only},
+            @software{Sturniolo_pymuon-suite_2022,
+                author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and Mudaraddi, Anish and {Muon Spectroscopy Computational Project}},
+                license = {GPL-3.0},
+                month = {8},
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
-                version = {v0.2.1},
-                month = {2},
-                year = {2022},
-                doi = {}
+                version = {v0.2.3},
+                year = {2022}
             }
         </token>
     </macros>
@@ -24,7 +27,7 @@
     <requirements>
         <!-- note versioning is different due to multiple dependencies -->
         <requirement type="package" version="21.2">dftbplus</requirement>
-        <requirement type="package" version="0.2.1">pymuonsuite</requirement>
+        <requirement type="package" version="@TOOL_VERSION@">pymuonsuite</requirement>
         <requirement type="package" version="3.0">zip</requirement>
     </requirements>
     <required_files>

--- a/pm_muairss_read/pm_muairss_read.xml
+++ b/pm_muairss_read/pm_muairss_read.xml
@@ -15,6 +15,7 @@
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
                 version = {v0.2.3},
+                doi = {10.5281/zenodo.7025644},
                 year = {2022}
             }
         </token>

--- a/pm_muairss_read/pm_muairss_read.xml
+++ b/pm_muairss_read/pm_muairss_read.xml
@@ -2,21 +2,20 @@
     <description>run clustering for optimised structures</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
-        <token name="@TOOL_VERSION@">0.2.1</token>
+        <token name="@TOOL_VERSION@">0.2.3</token>
         <!-- version of this tool wrapper (integer) -->
-        <token name="@WRAPPER_VERSION@">1</token>
+        <token name="@WRAPPER_VERSION@">0</token>
         <!-- citation should be updated with every underlying tool version -->
         <!-- typical fields to update are version, month, year, and doi -->
         <token name="@TOOL_CITATION@">
-            @software{pymuon-suite,
-                author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and {Muon Spectroscopy Computational Project}},
-                license = {GPL-3.0-only},
+            @software{Sturniolo_pymuon-suite_2022,
+                author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and Mudaraddi, Anish and {Muon Spectroscopy Computational Project}},
+                license = {GPL-3.0},
+                month = {8},
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
-                version = {v0.2.1},
-                month = {2},
-                year = {2022},
-                doi = {}
+                version = {v0.2.3},
+                year = {2022}
             }
         </token>
     </macros>

--- a/pm_muairss_write/pm_muairss_write.xml
+++ b/pm_muairss_write/pm_muairss_write.xml
@@ -2,21 +2,20 @@
     <description>generate muonated structures</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
-        <token name="@TOOL_VERSION@">0.2.1</token>
+        <token name="@TOOL_VERSION@">0.2.3</token>
         <!-- version of this tool wrapper (integer) -->
-        <token name="@WRAPPER_VERSION@">2</token>
+        <token name="@WRAPPER_VERSION@">0</token>
         <!-- citation should be updated with every underlying tool version -->
         <!-- typical fields to update are version, month, year, and doi -->
         <token name="@TOOL_CITATION@">
-            @software{pymuon-suite,
-                author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and {Muon Spectroscopy Computational Project}},
-                license = {GPL-3.0-only},
+            @software{Sturniolo_pymuon-suite_2022,
+                author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and Mudaraddi, Anish and {Muon Spectroscopy Computational Project}},
+                license = {GPL-3.0},
+                month = {8},
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
-                version = {v0.2.1},
-                month = {2},
-                year = {2022},
-                doi = {}
+                version = {v0.2.3},
+                year = {2022}
             }
         </token>
     </macros>

--- a/pm_muairss_write/pm_muairss_write.xml
+++ b/pm_muairss_write/pm_muairss_write.xml
@@ -15,6 +15,7 @@
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
                 version = {v0.2.3},
+                doi = {10.5281/zenodo.7025644},
                 year = {2022}
             }
         </token>

--- a/pm_nq/pm_nq.xml
+++ b/pm_nq/pm_nq.xml
@@ -15,6 +15,7 @@
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
                 version = {v0.2.3},
+                doi = {10.5281/zenodo.7025644},
                 year = {2022}
             }
         </token>

--- a/pm_nq/pm_nq.xml
+++ b/pm_nq/pm_nq.xml
@@ -2,21 +2,20 @@
     <description>generate and average displaced structures</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
-        <token name="@TOOL_VERSION@">0.2.1</token>
+        <token name="@TOOL_VERSION@">0.2.3</token>
         <!-- version of this tool wrapper (integer) -->
         <token name="@WRAPPER_VERSION@">0</token>
         <!-- citation should be updated with every underlying tool version -->
         <!-- typical fields to update are version, month, year, and doi -->
         <token name="@TOOL_CITATION@">
-            @software{pymuon-suite,
-                author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and {Muon Spectroscopy Computational Project}},
+            @software{Sturniolo_pymuon-suite_2022,
+                author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and Mudaraddi, Anish and {Muon Spectroscopy Computational Project}},
                 license = {GPL-3.0},
+                month = {8},
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
-                version = {v0.2.1},
-                month = {2},
-                year = {2022},
-                doi = {}
+                version = {v0.2.3},
+                year = {2022}
             }
         </token>
         <import>muon_macros.xml</import>

--- a/pm_symmetry/pm_symmetry.xml
+++ b/pm_symmetry/pm_symmetry.xml
@@ -2,21 +2,20 @@
     <description>generate Wyckoff points symmetry report</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
-        <token name="@TOOL_VERSION@">0.2.1</token>
+        <token name="@TOOL_VERSION@">0.2.3</token>
         <!-- version of this tool wrapper (integer) -->
-        <token name="@WRAPPER_VERSION@">1</token>
+        <token name="@WRAPPER_VERSION@">0</token>
         <!-- citation should be updated with every underlying tool version -->
         <!-- typical fields to update are version, month, year, and doi -->
         <token name="@TOOL_CITATION@">
-            @software{pymuon-suite,
-                author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and {Muon Spectroscopy Computational Project}},
-                license = {GPL-3.0-only},
+            @software{Sturniolo_pymuon-suite_2022,
+                author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and Mudaraddi, Anish and {Muon Spectroscopy Computational Project}},
+                license = {GPL-3.0},
+                month = {8},
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
-                version = {v0.2.1},
-                month = {2},
-                year = {2022},
-                doi = {}
+                version = {v0.2.3},
+                year = {2022}
             }
         </token>
     </macros>

--- a/pm_symmetry/pm_symmetry.xml
+++ b/pm_symmetry/pm_symmetry.xml
@@ -15,6 +15,7 @@
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
                 version = {v0.2.3},
+                doi = {10.5281/zenodo.7025644},
                 year = {2022}
             }
         </token>

--- a/pm_uep_opt/pm_uep_opt.xml
+++ b/pm_uep_opt/pm_uep_opt.xml
@@ -15,6 +15,7 @@
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
                 version = {v0.2.3},
+                doi = {10.5281/zenodo.7025644},
                 year = {2022}
             }
         </token>

--- a/pm_uep_opt/pm_uep_opt.xml
+++ b/pm_uep_opt/pm_uep_opt.xml
@@ -2,21 +2,20 @@
     <description>run UEP optimisation</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
-        <token name="@TOOL_VERSION@">0.2.1</token>
+        <token name="@TOOL_VERSION@">0.2.3</token>
         <!-- version of this tool wrapper (integer) -->
-        <token name="@WRAPPER_VERSION@">2</token>
+        <token name="@WRAPPER_VERSION@">0</token>
         <!-- citation should be updated with every underlying tool version -->
         <!-- typical fields to update are version, month, year, and doi -->
         <token name="@TOOL_CITATION@">
-            @software{pymuon-suite,
-                author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and {Muon Spectroscopy Computational Project}},
-                license = {GPL-3.0-only},
+            @software{Sturniolo_pymuon-suite_2022,
+                author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and Mudaraddi, Anish and {Muon Spectroscopy Computational Project}},
+                license = {GPL-3.0},
+                month = {8},
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
-                version = {v0.2.1},
-                month = {2},
-                year = {2022},
-                doi = {}
+                version = {v0.2.3},
+                year = {2022}
             }
         </token>
     </macros>

--- a/pm_yaml_config/pm_yaml_config.xml
+++ b/pm_yaml_config/pm_yaml_config.xml
@@ -4,21 +4,20 @@
         <!-- version of underlying tool (PEP 440) -->
         <!-- this wrapper doesn't have pymuonsuite as a dependency, but it will change according
              to the pymuonsuite interface, so follow the same versioning pattern -->
-        <token name="@TOOL_VERSION@">0.2.1</token>
+        <token name="@TOOL_VERSION@">0.2.3</token>
         <!-- version of this tool wrapper (integer) -->
         <token name="@WRAPPER_VERSION@">0</token>
         <!-- citation should be updated with every underlying tool version -->
         <!-- typical fields to update are version, month, year, and doi -->
         <token name="@TOOL_CITATION@">
-            @software{pymuon-suite,
-                author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and {Muon Spectroscopy Computational Project}},
-                license = {GPL-3.0-only},
+            @software{Sturniolo_pymuon-suite_2022,
+                author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and Mudaraddi, Anish and {Muon Spectroscopy Computational Project}},
+                license = {GPL-3.0},
+                month = {8},
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
-                version = {v0.2.1},
-                month = {2},
-                year = {2022},
-                doi = {}
+                version = {v0.2.3},
+                year = {2022}
             }
         </token>
         <import>muon_macros.xml</import>

--- a/pm_yaml_config/pm_yaml_config.xml
+++ b/pm_yaml_config/pm_yaml_config.xml
@@ -17,6 +17,7 @@
                 title = {{pymuon-suite}},
                 url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
                 version = {v0.2.3},
+                doi = {10.5281/zenodo.7025644},
                 year = {2022}
             }
         </token>


### PR DESCRIPTION
Increment `@TOOL_VERSION@` and reset `@WRAPPER_VERSION@` for all PyMuonSuite tools. In asephonons and dftb opt, introduce the macro tags.

Reviewing https://github.com/muon-spectroscopy-computational-project/pymuon-suite/compare/v0.2.1...v0.2.3 did not see any 
functional changes required for the wrappers.

#83 