### PR TITLE
Add cluster save options and refactor config #125

### DIFF
--- a/pm_muairss_read/pm_muairss_read.xml
+++ b/pm_muairss_read/pm_muairss_read.xml
@@ -28,6 +28,7 @@
     </creator>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">pymuonsuite</requirement>
+        <requirement type="package" version="3.0">zip</requirement>
     </requirements>
     <required_files>
         <include type="literal" path="get_out_folder.py"/>

--- a/pm_muairss_read/pm_muairss_read.xml
+++ b/pm_muairss_read/pm_muairss_read.xml
@@ -23,6 +23,7 @@
     <creator>
         <person givenName="Jyothish" familyName="Thomas" identifier="https://orcid.org/0000-0003-4724-6924"/>
         <person givenName="Eli" familyName="Chadwick" url="https://github.com/elichad" identifier="https://orcid.org/0000-0002-0035-6475"/>
+        <person givenName="Patrick" familyName="Austin" url="https://github.com/patrick-austin"/>
         <organization url="https://muon-spectroscopy-computational-project.github.io/index.html" name="The Muon Spectroscopy Computational Project"/>
     </creator>
     <requirements>
@@ -36,14 +37,51 @@
         if test -f "params.yaml"; then echo "params.yaml present"; else echo "params.yaml missing" && exit 64; fi
         && if ( test -f input_structure.* ) ; then echo "input structure present"; else echo "input structure missing" && exit 64; fi
         && out_folder="`python '${__tool_directory__}/get_out_folder.py'`" &&
+        #if $clustering_save.clustering_save_type != "none":
+            sed -i '/^clustering_save_type: /{h;s/:.*/: '"$clustering_save.clustering_save_type"'/};\${x;/^$/{s//clustering_save_type: '"$clustering_save.clustering_save_type"'/;H};x}' params.yaml &&
+            sed -i '/^clustering_save_format: /{h;s/:.*/: '"$clustering_save.clustering_save_format"'/};\${x;/^$/{s//clustering_save_format: '"$clustering_save.clustering_save_format"'/;H};x}' params.yaml &&
+        #end if
         pm-muairss -t r input_structure.* params.yaml
+        #if $clustering_save.clustering_save_type == "structures":
+            && ln -s *_clusters/* minimal_clusters
+        #else if $clustering_save.clustering_save_type == "input":
+            && zip -r saved_inputs.zip *_clusters
+        #end if
     ]]></command>
     <inputs>
         <param type="data" name="optimisation_results" label="optimised muonated structures (.zip)" format="zip" help="A zip folder containing a set of optimised muonated structures, the original structure, and a YAML parameter file. See below for the expected folder structure."/>
+        <conditional name="clustering_save">
+            <param argument="clustering_save_type" type="select" value="none" label="Clutering Save Type" help="If set, for each cluster either a structural file or a set of files for subsequent calculation will be generated, corresponding to the structure in the cluster with minimal energy.">
+                <option value="none">Do not generate</option>
+                <option value="structures">Structures</option>
+                <option value="input">Input</option>
+            </param>
+            <when value="none"/>
+            <when value="structures">
+                <param argument="clustering_save_format" type="select" display="radio" value="cell" label="Clutering Save Format" help="The format to save each cluster's minimum energy structure as.">
+                    <option value="cell">CELL</option>
+                    <option value="cif">CIF</option>
+                    <option value="xyz">XYZ</option>
+                </param>
+            </when>
+            <when value="input">
+                <param argument="clustering_save_format" type="select" display="radio" value="castep" label="Clutering Save Format" help="The format to save each cluster's input files as.">
+                    <option value="castep">CASTEP</option>
+                    <option value="dftb+">DFTB+</option>
+                </param>
+            </when>
+        </conditional>
     </inputs>
     <outputs>
         <data label="Cluster report for $optimisation_results.name" name="cluster_report" format="txt" from_work_dir="${out_folder}/*clusters.txt"/>
         <data label="Cluster data for $optimisation_results.name" name="cluster_data" format="txt" from_work_dir="${out_folder}/*clusters.dat"/>
+        <collection name="saved_structures" type="list" label="Minimal energy structures" format="txt">
+            <filter>clustering_save["clustering_save_type"] == "structures"</filter>
+            <discover_datasets pattern="__name_and_ext__" directory="minimal_clusters"/>
+        </collection>
+        <data name="saved_inputs" label="Minimal energy inputs" format="zip" from_work_dir="saved_inputs.zip">
+            <filter>clustering_save["clustering_save_type"] == "input"</filter>
+        </data>
     </outputs>
     <tests>
         <test expect_num_outputs="2">
@@ -51,10 +89,37 @@
             <output name="cluster_report" file="clustout-uep.txt" ftype="txt" lines_diff="2"/>
             <output name="cluster_data" file="clustout-uep.dat" ftype="txt"/>
         </test>
+        <test expect_num_outputs="3">
+            <param name="optimisation_results" value="uep-out.zip" ftype="zip"/>
+            <conditional name="clustering_save">
+                <param name="clustering_save_type" value="structures"/>
+                <param name="clustering_save_format" value="cell"/>
+            </conditional>
+            <output name="cluster_report" file="clustout-uep.txt" ftype="txt" lines_diff="2"/>
+            <output name="cluster_data" file="clustout-uep.dat" ftype="txt"/>
+            <output_collection name="saved_structures" type="list" count="2"/>
+        </test>
         <test expect_num_outputs="2">
             <param name="optimisation_results" value="dftb-out.zip" ftype="zip"/>
             <output name="cluster_report" file="clustout-dftb.txt" ftype="txt" lines_diff="2"/>
             <output name="cluster_data" file="clustout-dftb.dat" ftype="txt"/>
+        </test>
+        <test expect_num_outputs="3">
+            <param name="optimisation_results" value="dftb-out.zip" ftype="zip"/>
+            <conditional name="clustering_save">
+                <param name="clustering_save_type" value="input"/>
+                <param name="clustering_save_format" value="dftb+"/>
+            </conditional>
+            <output name="cluster_report" file="clustout-dftb.txt" ftype="txt" lines_diff="2"/>
+            <output name="cluster_data" file="clustout-dftb.dat" ftype="txt"/>
+            <output name="saved_inputs" ftype="zip">
+                <assert_contents>
+                    <has_archive_member path="Si_clusters\/dftb\.LICENSE"/>
+                    <has_archive_member path="Si_clusters\/dftb\+\/\.collection"/>
+                    <has_archive_member path="Si_clusters\/dftb\+\/Si_min_cluster_\d\/dftb_in\.hsd" n="3"/>
+                    <has_archive_member path="Si_clusters\/dftb\+\/Si_min_cluster_\d\/geo_end\.gen" n="3"/>
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help><![CDATA[

--- a/pm_yaml_config/pm_yaml_config.xml
+++ b/pm_yaml_config/pm_yaml_config.xml
@@ -26,53 +26,93 @@
     <creator>
         <person givenName="Jyothish" familyName="Thomas" identifier="https://orcid.org/0000-0003-4724-6924"/>
         <person givenName="Eli" familyName="Chadwick" url="https://github.com/elichad" identifier="https://orcid.org/0000-0002-0035-6475"/>
+        <person givenName="Patrick" familyName="Austin" url="https://github.com/patrick-austin"/>
         <organization url="https://muon-spectroscopy-computational-project.github.io/index.html" name="The Muon Spectroscopy Computational Project"/>
     </creator>
     <requirements>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        touch outputx.yaml &&
-        ([[ ! -z '$general_params.poisson_r' ]] && printf 'poisson_r: $general_params.poisson_r\n'>>outputx.yaml || ( >&2 echo "poisson_r empty" && exit 2)) &&
-        ([[ ! -z '$general_params.name' ]] && printf 'name: $general_params.name\n'>>outputx.yaml || ( >&2 echo "structure name is empty" && exit 2)) &&
-        ([[ ! -z '$general_params.charged' ]] && printf 'charged: $general_params.charged\n'>>outputx.yaml || ( >&2 echo "charged muon empty" && exit 2)) &&
-        ([[ ! -z '$general_params.geom_steps' ]] && printf 'geom_steps: $general_params.geom_steps\n'>>outputx.yaml || ( >&2 echo "geom_steps empty" && exit 2)) &&
-        ([[ ! -z '$general_params.vdw_scale' ]] && printf 'vdw_scale: $general_params.vdw_scale\n'>>outputx.yaml || ( >&2 echo "vdw_scale empty" && exit 2)) &&
-        ([[ ! -z '$calculator_params.calculator_cond.calculator' ]] && printf 'calculator: $calculator_params.calculator_cond.calculator\n'>>outputx.yaml || ( >&2 echo "calculator unselected" && exit 2)) &&
-        ([[ ! -z '$general_params.geom_force_tol' ]] && printf 'geom_force_tol: $general_params.geom_force_tol\n'>>outputx.yaml || ( >&2 echo "geom_force_tol empty" && exit 2)) &&
-        ([[ ! -z '$general_params.out_folder' ]] && printf 'out_folder: $general_params.out_folder\n'>>outputx.yaml || printf "out_folder: muon-airss-out\n">>outputx.yaml) &&
-        ([[ ! -z '$general_params.random_seed' ]] && printf 'random_seed: $general_params.random_seed\n'>>outputx.yaml || ( echo "random_seed empty")) &&
-        ([[ ! -z '$clustering_params.supercell' ]] && (printf 'supercell: $clustering_params.supercell\n' | sed "s/__ob__/[/g" | sed "s/__cb__/]/g" )>>outputx.yaml || ( >&2 echo "supercell empty" && exit 2)) &&
-        ([[ ! -z '$clustering_params.k_points_grid' ]] && (printf 'k_points_grid: $clustering_params.k_points_grid\n' | sed "s/__ob__/[/g" | sed "s/__cb__/]/g" ) >>outputx.yaml || ( >&2 echo "k_points_grid empty" && exit 2)) &&
-        ([[ ! -z '$clustering_params.max_scc_steps' ]] && printf 'max_scc_steps: $clustering_params.max_scc_steps\n'>>outputx.yaml || ( >&2 echo "max_scc_steps empty")) &&
-        #if str($calculator_params.calculator_cond.calculator)=="uep":
-            ([[ ! -z '$calculator_params.calculator_cond.uep_gw_factor' ]] && printf 'uep_gw_factor: $calculator_params.calculator_cond.uep_gw_factor\n'>>outputx.yaml || ( >&2 echo "uep gaussian width unset" && exit 2)) &&
-            ([[ ! -z '$calculator_params.calculator_cond.uep_chden' ]] && printf 'uep_chden: $calculator_params.calculator_cond.uep_chden.value\n'>>outputx.yaml || echo "den_fmt path unset") &&
-        #else if str($calculator_params.calculator_cond.calculator)=="CASTEP":
-            ([[ ! -z '$calculator_params.calculator_cond.castep_command' ]] && printf 'castep_command: $calculator_params.calculator_cond.castep_command\n'>>outputx.yaml || echo "CASTEP command unset") &&
-            ([[ ! -z '$calculator_params.calculator_cond.castep_param' ]] && printf 'castep_param: $calculator_params.calculator_cond.castep_param\n'>>outputx.yaml || echo "CASTEP param unset") &&
-            ([[ ! -z '$calculator_params.calculator_cond.mu_symbol' ]] && printf 'mu_symbol: $calculator_params.calculator_cond.mu_symbol\n'>>outputx.yaml || echo "mu symbol unset") &&
-        #else if str($calculator_params.calculator_cond.calculator)=="dftb+":
-            ([[ ! -z '$calculator_params.calculator_cond.dftb_set' ]] && printf 'dftb_set: $calculator_params.calculator_cond.dftb_set\n'>>outputx.yaml || ( >&2 echo "dftb parameter set unselected" && exit 2)) &&
-            ([[ ! -z '$calculator_params.calculator_cond.dftb_optionals' ]] && (printf 'dftb_optionals: $calculator_params.calculator_cond.dftb_optionals\n' | sed "s/__ob__/[/g" | sed "s/__cb__/]/g" ) >>outputx.yaml || echo "dftb optional json files unset") &&
-            ([[ ! -z '$calculator_params.calculator_cond.dftb_pbc' ]] && printf 'dftb_pbc: $calculator_params.calculator_cond.dftb_pbc\n'>>outputx.yaml || echo "dftb periodic boundary condition unselected") &&
-        #else if str($calculator_params.calculator_cond.calculator)=="all":
-            ([[ ! -z '$calculator_params.calculator_cond.uep_gw_factor' ]] && printf 'uep_gw_factor: $calculator_params.calculator_cond.uep_gw_factor\n'>>outputx.yaml || echo "uep gaussian width unset") &&
-            ([[ ! -z '$calculator_params.calculator_cond.uep_chden' ]] && printf 'uep_chden: $calculator_params.calculator_cond.uep_chden\n'>>outputx.yaml || echo "den_fmt path unset") &&
-            ([[ ! -z '$calculator_params.calculator_cond.castep_command' ]] && printf 'castep_command: $calculator_params.calculator_cond.castep_command\n'>>outputx.yaml || echo "CASTEP command unset") &&
-            ([[ ! -z '$calculator_params.calculator_cond.castep_param' ]] && printf 'castep_param: $calculator_params.calculator_cond.castep_param\n'>>outputx.yaml || echo "CASTEP param unset") &&
-            ([[ ! -z '$calculator_params.calculator_cond.mu_symbol' ]] && printf 'mu_symbol: $calculator_params.calculator_cond.mu_symbol\n'>>outputx.yaml || echo "mu symbol unset") &&
-            ([[ ! -z '$calculator_params.calculator_cond.dftb_set' ]] && printf 'dftb_set: $calculator_params.calculator_cond.dftb_set\n'>>outputx.yaml || echo "dftb parameter set unselected") &&
-            ([[ ! -z '$calculator_params.calculator_cond.dftb_optionals' ]] && (printf 'dftb_optionals: $calculator_params.calculator_cond.dftb_optionals\n' | sed "s/__ob__/[/g" | sed "s/__cb__/]/g" ) >>outputx.yaml || echo "dftb optional json files unset") &&
-            ([[ ! -z '$calculator_params.calculator_cond.dftb_pbc' ]] && printf 'dftb_pbc: $calculator_params.calculator_cond.dftb_pbc\n'>>outputx.yaml || echo "dftb periodic boundary condition unselected") &&
-        #end if
-        ([[ ! -z '$clustering_params.clustering.clustering_method' ]] && printf 'clustering_method: $clustering_params.clustering.clustering_method\n'>>outputx.yaml || ( echo "clustering method unselected" && exit 2)) &&
-        #if str($clustering_params.clustering.clustering_method)=="hier":
-            ([[ ! -z '$clustering_params.clustering.clustering_hier_t' ]] && printf 'clustering_hier_t: $clustering_params.clustering.clustering_hier_t\n'>>outputx.yaml || echo "clustering_hier_t unset") &&
-        #else if str($clustering_params.clustering.clustering_method)=="kmeans":
-            ([[ ! -z '$clustering_params.clustering.clustering_kmeans_k' ]] && printf 'clustering_kmeans_k: $clustering_params.clustering.clustering_kmeans_k\n'>>outputx.yaml || echo "clustering_kmeans_k unset") &&
-        #end if
-        ln -s outputx.yaml output.yaml
+        cat $params_yaml > $out_yaml
     ]]></command>
+    <configfiles>
+        <configfile name="params_yaml">poisson_r: $general_params.poisson_r
+name: $general_params.name
+charged: $general_params.charged
+geom_steps: $general_params.geom_steps
+vdw_scale: $general_params.vdw_scale
+calculator: $calculator_params.calculator_cond.calculator
+geom_force_tol: $general_params.geom_force_tol
+#if $general_params.out_folder:
+out_folder: $general_params.out_folder
+#else
+out_folder: muon-airss-out
+#end if
+#if $general_params.random_seed:
+random_seed: $general_params.random_seed
+#end if
+supercell: $clustering_params.supercell.replace('__ob__', '[').replace('__cb__', ']')
+k_points_grid: $clustering_params.k_points_grid.replace('__ob__', '[').replace('__cb__', ']')
+#if $clustering_params.max_scc_steps:
+max_scc_steps: $clustering_params.max_scc_steps
+#end if
+#if str($calculator_params.calculator_cond.calculator)=="uep":
+uep_gw_factor: $calculator_params.calculator_cond.uep_gw_factor
+#if $calculator_params.calculator_cond.uep_chden.value:
+uep_chden: $calculator_params.calculator_cond.uep_chden.value
+#end if
+#else if str($calculator_params.calculator_cond.calculator)=="CASTEP":
+#if $calculator_params.calculator_cond.castep_command:
+castep_command: $calculator_params.calculator_cond.castep_command
+#end if
+#if $calculator_params.calculator_cond.castep_param:
+castep_param: $calculator_params.calculator_cond.castep_param
+#end if
+#if $calculator_params.calculator_cond.mu_symbol:
+mu_symbol: $calculator_params.calculator_cond.mu_symbol
+#end if
+#else if str($calculator_params.calculator_cond.calculator)=="dftb+":
+#if $calculator_params.calculator_cond.dftb_set:
+dftb_set: $calculator_params.calculator_cond.dftb_set
+#end if
+#if $calculator_params.calculator_cond.dftb_optionals:
+dftb_optionals: $calculator_params.calculator_cond.dftb_optionals.replace('__ob__', '[').replace('__cb__', ']')
+#end if
+#if $calculator_params.calculator_cond.dftb_pbc:
+dftb_pbc: $calculator_params.calculator_cond.dftb_pbc
+#end if
+#else if str($calculator_params.calculator_cond.calculator)=="all":
+#if $calculator_params.calculator_cond.uep_gw_factor:
+uep_gw_factor: $calculator_params.calculator_cond.uep_gw_factor
+#end if
+#if $calculator_params.calculator_cond.uep_chden:
+uep_chden: $calculator_params.calculator_cond.uep_chden
+#end if
+#if $calculator_params.calculator_cond.castep_command:
+castep_command: $calculator_params.calculator_cond.castep_command
+#end if
+#if $calculator_params.calculator_cond.castep_param:
+castep_param: $calculator_params.calculator_cond.castep_param
+#end if
+#if $calculator_params.calculator_cond.mu_symbol:
+mu_symbol: $calculator_params.calculator_cond.mu_symbol
+#end if
+#if $calculator_params.calculator_cond.dftb_set:
+dftb_set: $calculator_params.calculator_cond.dftb_set
+#end if
+#if $calculator_params.calculator_cond.dftb_optionals:
+dftb_optionals: $calculator_params.calculator_cond.dftb_optionals.replace('__ob__', '[').replace('__cb__', ']')
+#end if
+#if $calculator_params.calculator_cond.dftb_pbc:
+dftb_pbc: $calculator_params.calculator_cond.dftb_pbc
+#end if
+#end if
+clustering_method: $clustering_params.clustering.clustering_method
+#if str($clustering_params.clustering.clustering_method)=="hier":
+clustering_hier_t: $clustering_params.clustering.clustering_hier_t
+#else if str($clustering_params.clustering.clustering_method)=="kmeans":
+clustering_kmeans_k: $clustering_params.clustering.clustering_kmeans_k
+#end if</configfile>
+    </configfiles>
     <inputs>
         <section name="general_params" expanded="true" title="General Parameters">
             <param type="float" argument="poisson_r" value="0.8" min="0.0" label="Poisson radius" help=" Poisson sphere radius to use for random generation. No two starting muon positions will be closer than this distance. Smaller values make for bigger structure sets."/>
@@ -137,7 +177,7 @@
         </section>
     </inputs>
     <outputs>
-        <data label="Configuration for $general_params.name" name="out_yaml" format="yaml" from_work_dir="output.yaml"/>
+        <data label="Configuration for $general_params.name" name="out_yaml" format="yaml"/>
     </outputs>
     <tests>
         <test expect_num_outputs="1">


### PR DESCRIPTION
Adds the `clustering_save_type` and `clustering_save_format` arguments to `pm_muairss_read`. Initially I was going to add them to `pm_yaml_config`, however it was then difficult to extract the (optional) outputs with `read` - adding the parameters directly to the read form made it possible to use them in filters so that we only generate outputs when they are needed. Note that this is related to the open issues regarding the refactor of config parameters: #99 and #100.

In terms of the implementation, for `structures` we are able to use a Galaxy `list` collection which contains each structure file. For `input` this was more difficult:
 - We have heterogeneous file types (e.g. `.gen` and `.hsd` for DFTB+) which are not (currently) supported in Galaxy. These can be explicitly set as `.txt` files, but I suspect this would cause trouble if trying to run further calculations as it can be particular about the naming pattern (including extension) it expects.
 - There appeared to be a bug with `list:list` collections where they won't display in the UI (or at least I couldn't get it to work): galaxyproject/galaxy#15520

Ultimately it seemed better to just zip the whole tree for `input`. We already do this in other places anyway, and can revisit in the future if we want. 

Closes #125 