### PR TITLE
Add warning to cif2cell tool #127

### DIFF
--- a/cif2cell/cif2cell.xml
+++ b/cif2cell/cif2cell.xml
@@ -39,8 +39,16 @@
     <help><![CDATA[
         usage: cif2cell -f file.cif -p castep -o file.cell
 
-        Given an input .cif structure file, convert to an equivalent .cell
+        Given an input ``.cif`` structure file, convert to an equivalent ``.cell``
         structure file for use with electronic structure program CASTEP.
+
+        .. class:: warningmark
+            warning
+
+        **WARNING**: ``.cif`` files may contain errors that prevent cif2cell from running properly.
+        If you find that you run cif2cell and do not get a satisfactory ``.cell`` file,
+        please consider revising the corresponding ``.cif`` file and, if necessary,
+        obtaining an alternative ``.cif`` file from a suitable crystalline database.
 
         cif2cell is distributed under the GPLv3 license. This tool wrapper is distributed under the MIT license.
     ]]></help>


### PR DESCRIPTION
Added warning to cif2cell regarding the unreliability of input `.cif` files.

Also added double backticks to the file extensions for emphasis.

![image](https://user-images.githubusercontent.com/61705287/221190036-9f659863-fc4c-4d81-8169-1792096d1a65.png)
