### PR TITLE
Changed output labels

### DIFF
--- a/cif2cell/cif2cell.xml
+++ b/cif2cell/cif2cell.xml
@@ -28,7 +28,7 @@
         <param argument="--cartesian" type="boolean" truevalue="--cartesian" falsevalue="" label="Do you want to generate any output in cartesian coordinates?" help="Use a cif file to convert into a structural (cell) file." />
     </inputs>
     <outputs>
-        <data label="Conversion of $file.name to .cell" name="out_cell" format="cell" from_work_dir="out.cell" />
+        <data name="out_cell" format="cell" from_work_dir="out.cell" />
     </outputs>
     <tests>
         <test expect_num_outputs="1">

--- a/muspinsim/muspinsim.xml
+++ b/muspinsim/muspinsim.xml
@@ -51,8 +51,8 @@
         <collection name="muspinsim_results" type="list" label="Muspinsim output collection">
             <discover_datasets pattern="__name__" directory="data" format="txt"/>
         </collection>
-        <data label="muspinsim log for $mu_sim.name" name="log_out" format="txt" from_work_dir="log_out.log"/>
-        <data label="fit report for $mu_sim.name" name="fit_report" format="txt" from_work_dir="fit_report.txt">
+        <data label="muspinsim log on ${on_string}" name="log_out" format="txt" from_work_dir="log_out.log"/>
+        <data label="fit report on ${on_string}" name="fit_report" format="txt" from_work_dir="fit_report.txt">
             <filter>mu_exp_in</filter>
         </data>
     </outputs>

--- a/pm_asephonons/pm_asephonons.xml
+++ b/pm_asephonons/pm_asephonons.xml
@@ -63,8 +63,8 @@ force_clean: false</configfile>
         </conditional>
     </inputs>
     <outputs>
-        <data label="phonons outputs of $pbc.structure.name" name="phonon_outputs" format="zip" from_work_dir="out_zip.zip"/>
-        <data label="phonon report for $pbc.structure.name" name="phonon_report" format="txt" from_work_dir="phonon_report.txt"/>
+        <data label="phonons outputs on ${on_string}" name="phonon_outputs" format="zip" from_work_dir="out_zip.zip"/>
+        <data label="phonon report on ${on_string}" name="phonon_report" format="txt" from_work_dir="phonon_report.txt"/>
     </outputs>
     <tests>
         <test expect_num_outputs="2">

--- a/pm_dftb_opt/pm_dftb_opt.xml
+++ b/pm_dftb_opt/pm_dftb_opt.xml
@@ -54,7 +54,7 @@
         <param type="hidden" name="testing" label="Test mode" value="false"/>
     </inputs>
     <outputs>
-        <data label="DFTB results for $muonated_structures.name" name="dftb_results" format="zip" from_work_dir="dftb_results.zip"/>
+        <data label="DFTB results on ${on_string}" name="dftb_results" format="zip" from_work_dir="dftb_results.zip"/>
         <data label="File tree (testing only)" name="file_tree" format="txt" from_work_dir="tree.txt" hidden="true">
             <filter>(testing == "true")</filter>
         </data>

--- a/pm_muairss_read/pm_muairss_read.xml
+++ b/pm_muairss_read/pm_muairss_read.xml
@@ -86,9 +86,9 @@ mu_symbol: $clustering_save.mu_symbol
         </conditional>
     </inputs>
     <outputs>
-        <data label="Cluster report for $optimisation_results.name" name="cluster_report" format="txt" from_work_dir="${out_folder}/*clusters.txt"/>
-        <data label="Cluster data for $optimisation_results.name" name="cluster_data" format="txt" from_work_dir="${out_folder}/*clusters.dat"/>
-        <collection name="saved_structures" type="list" label="Minimal energy structures" format="txt">
+        <data label="Cluster report on ${on_string}" name="cluster_report" format="txt" from_work_dir="${out_folder}/*clusters.txt"/>
+        <data label="Cluster data on ${on_string}" name="cluster_data" format="txt" from_work_dir="${out_folder}/*clusters.dat"/>
+        <collection name="saved_structures" type="list" label="Minimal energy structures on ${on_string}" format="txt">
             <filter>clustering_save["clustering_save_format"] != "none"</filter>
             <discover_datasets pattern="__name_and_ext__" directory="minimal_clusters"/>
         </collection>

--- a/pm_nq/pm_nq.xml
+++ b/pm_nq/pm_nq.xml
@@ -161,13 +161,13 @@ castep_param: $castep_param_name
         <param type="hidden" name="testing" label="Test mode" value="false"/>
     </inputs>
     <outputs>
-        <data label="Displaced Structures" name="displaced_structures" format="zip" from_work_dir="out_zip.zip">
+        <data label="Displaced Structures on ${on_string}" name="displaced_structures" format="zip" from_work_dir="out_zip.zip">
             <filter>(task['task'] == 'write')</filter>
         </data>
         <data label="File tree (testing only)" name="file_tree" format="txt" from_work_dir="tree.txt" hidden="true">
             <filter>(task['task'] == 'write' and testing == 'true')</filter>
         </data>
-        <data label="Averaged Property" name="averaged_property" format="txt" from_work_dir="averages.dat">
+        <data label="Averaged Property on ${on_string}" name="averaged_property" format="txt" from_work_dir="averages.dat">
             <filter>(task['task'] == 'read')</filter>
         </data>
     </outputs>

--- a/pm_symmetry/pm_symmetry.xml
+++ b/pm_symmetry/pm_symmetry.xml
@@ -22,7 +22,7 @@
         <param type="data" name="structure" label="Structure file" format="cell,cif,xyz,extxyz" help="The structure to calculate symmetries of. Accepted file types: cell."/>
     </inputs>
     <outputs>
-        <data label="symmetry of $structure.name" name="symmetry_report" format="txt" from_work_dir="out.txt"/>
+        <data name="symmetry_report" format="txt" from_work_dir="out.txt"/>
     </outputs>
     <tests>
         <test expect_num_outputs="1">

--- a/pm_uep_opt/pm_uep_opt.xml
+++ b/pm_uep_opt/pm_uep_opt.xml
@@ -75,7 +75,7 @@ uep_gw_factor: $optimisation_params.uep_gw_factor</configfile>
     </inputs>
     <outputs>
         <data name="uep_results" format="zip" from_work_dir="out_zip.zip"/>
-        <data label="File containing the positions of all muon sites" name="allpos_file" auto_format="true">
+        <data label="Muon site positions on ${on_string}" name="allpos_file" auto_format="true">
             <filter>(generation_params["allpos_ext"] != "none")</filter>
         </data>
         <data label="File tree (testing only)" name="file_tree" format="txt" from_work_dir="tree.txt" hidden="true">

--- a/pm_yaml_config/pm_yaml_config.xml
+++ b/pm_yaml_config/pm_yaml_config.xml
@@ -165,7 +165,7 @@ clustering_kmeans_k: $clustering_params.clustering.clustering_kmeans_k
         </section>
     </inputs>
     <outputs>
-        <data label="Configuration for $general_params.name" name="out_yaml" format="yaml"/>
+        <data name="out_yaml" format="yaml"/>
     </outputs>
     <tests>
         <test expect_num_outputs="1">


### PR DESCRIPTION
Made most output labels follow a
"unique text on ${on_string}" format in the case
of multiple outputs else removed label entirely.

A few discrepancies worth discussing:
* **muspinsim_config.xml**: label removal shows up as "MuSpinSim Configure" instead of "${tool.name} on ${on_string}", so have left it as is for now.
* **pm_dftb_opt.xml**: The "File tree (testing only)" label was left as is since I could not see it in the output.
* **pm_muairss_read.xml**: The collection label says "minimum energy structures". Changed it but doubtful
* **pm_muairss_write.xml**: labels need reviewing 